### PR TITLE
Elixir fly deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - run: flyctl deploy --remote-only
+        working-directory: ./elixir
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-

--- a/elixir/.dockerignore
+++ b/elixir/.dockerignore
@@ -1,0 +1,46 @@
+# This file excludes paths from the Docker build context.
+#
+# By default, Docker's build context includes all files (and folders) in the
+# current directory. Even if a file isn't copied into the container it is still sent to
+# the Docker daemon.
+#
+# There are multiple reasons to exclude files from the build context:
+#
+# 1. Prevent nested folders from being copied into the container (ex: exclude
+#    /assets/node_modules when copying /assets)
+# 2. Reduce the size of the build context and improve build time (ex. /build, /deps, /doc)
+# 3. Avoid sending files containing sensitive information
+#
+# More information on using .dockerignore is available here:
+# https://docs.docker.com/engine/reference/builder/#dockerignore-file
+
+.dockerignore
+
+# Ignore git, but keep git HEAD and refs to access current commit hash if needed:
+#
+# $ cat .git/HEAD | awk '{print ".git/"$2}' | xargs cat
+# d0b8727759e1e0e7aa3d41707d12376e373d5ecc
+.git
+!.git/HEAD
+!.git/refs
+
+# Common development/test artifacts
+/cover/
+/doc/
+/test/
+/tmp/
+.elixir_ls
+
+# Mix artifacts
+/_build/
+/deps/
+*.ez
+
+# Generated on crash by the VM
+erl_crash.dump
+
+# Static artifacts - These should be fetched and built inside the Docker image
+# https://hexdocs.pm/phoenix/Mix.Tasks.Phx.Gen.Release.html#module-docker
+/assets/node_modules/
+/priv/static/assets/
+/priv/static/cache_manifest.json

--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -1,0 +1,101 @@
+# Find eligible builder and runner images on Docker Hub. We use Ubuntu/Debian
+# instead of Alpine to avoid DNS resolution issues in production.
+#
+# https://hub.docker.com/r/hexpm/elixir/tags?name=ubuntu
+# https://hub.docker.com/_/ubuntu/tags
+#
+# This file is based on these images:
+#
+#   - https://hub.docker.com/r/hexpm/elixir/tags - for the build image
+#   - https://hub.docker.com/_/debian/tags?name=trixie-20260223-slim - for the release image
+#   - https://pkgs.org/ - resource for finding needed packages
+#   - Ex: docker.io/hexpm/elixir:1.19.1-erlang-28.1.1-debian-trixie-20260223-slim
+#
+ARG ELIXIR_VERSION=1.19.1
+ARG OTP_VERSION=28.1.1
+ARG DEBIAN_VERSION=trixie-20260223-slim
+
+ARG BUILDER_IMAGE="docker.io/hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
+ARG RUNNER_IMAGE="docker.io/debian:${DEBIAN_VERSION}"
+
+FROM ${BUILDER_IMAGE} AS builder
+
+# install build dependencies
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends build-essential git \
+  && rm -rf /var/lib/apt/lists/*
+
+# prepare build dir
+WORKDIR /app
+
+# install hex + rebar
+RUN mix local.hex --force \
+  && mix local.rebar --force
+
+# set build ENV
+ENV MIX_ENV="prod"
+
+# install mix dependencies
+COPY mix.exs mix.lock ./
+RUN mix deps.get --only $MIX_ENV
+RUN mkdir config
+
+# copy compile-time config files before we compile dependencies
+# to ensure any relevant config change will trigger the dependencies
+# to be re-compiled.
+COPY config/config.exs config/${MIX_ENV}.exs config/
+RUN mix deps.compile
+
+RUN mix assets.setup
+
+COPY priv priv
+
+COPY lib lib
+
+# Compile the release
+RUN mix compile
+
+COPY assets assets
+
+# compile assets
+RUN mix assets.deploy
+
+# Changes to config/runtime.exs don't require recompiling the code
+COPY config/runtime.exs config/
+
+COPY rel rel
+RUN mix release
+
+# start a new build stage so that the final image will only contain
+# the compiled release and other runtime necessities
+FROM ${RUNNER_IMAGE} AS final
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends libstdc++6 openssl libncurses6 locales ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+# Set the locale
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
+  && locale-gen
+
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+
+WORKDIR "/app"
+RUN chown nobody /app
+
+# set runner ENV
+ENV MIX_ENV="prod"
+
+# Only copy the final release from the build stage
+COPY --from=builder --chown=nobody:root /app/_build/${MIX_ENV}/rel/flamingo ./
+
+USER nobody
+
+# If using an environment that doesn't automatically reap zombie processes, it is
+# advised to add an init process such as tini via `apt-get install`
+# above and adding an entrypoint. See https://github.com/krallin/tini for details
+# ENTRYPOINT ["/tini", "--"]
+
+CMD ["/app/bin/server"]

--- a/elixir/fly.toml
+++ b/elixir/fly.toml
@@ -1,0 +1,26 @@
+app = 'flamingo'
+primary_region = 'lhr'
+
+[build]
+
+[env]
+  PHX_HOST = 'flamingo.fly.dev'
+  PHX_SERVER = 'true'
+
+[http_service]
+  internal_port = 4000
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
+
+[http_service.concurrency]
+  type = 'connections'
+  hard_limit = 1000
+  soft_limit = 1000
+
+[[vm]]
+  memory = '1gb'
+  cpu_kind = 'shared'
+  cpus = 1

--- a/elixir/rel/overlays/bin/server
+++ b/elixir/rel/overlays/bin/server
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+cd -P -- "$(dirname -- "$0")"
+PHX_SERVER=true exec ./flamingo start

--- a/elixir/rel/overlays/bin/server.bat
+++ b/elixir/rel/overlays/bin/server.bat
@@ -1,0 +1,2 @@
+set PHX_SERVER=true
+call "%~dp0\flamingo" start


### PR DESCRIPTION
This pull request introduces configuration and infrastructure changes to enable building and deploying the Elixir application (`flamingo`) via Docker and Fly.io. The changes add a production-ready Dockerfile, a `.dockerignore` to optimize builds, and Fly.io deployment configuration, and update the GitHub Actions workflow to deploy from the correct directory.

**Deployment and Build Configuration:**

* Added a production-ready `Dockerfile` for the Elixir application, using multi-stage builds to keep the final image minimal and secure, and including steps for dependency installation, asset compilation, and release creation.
* Added a comprehensive `.dockerignore` file to exclude unnecessary files and directories from the Docker build context, improving build performance and security.
* Added a `fly.toml` configuration file to define Fly.io deployment settings, such as app name, region, environment variables, service ports, concurrency, and VM resources.

**CI/CD Workflow Update:**

* Updated the GitHub Actions deployment workflow to set the `working-directory` to `./elixir` for the Fly.io deployment step, ensuring the deployment command runs in the correct context.