### PR TITLE
Fix game feed panel height

### DIFF
--- a/elixir/lib/flamingo_web/live/game_live.ex
+++ b/elixir/lib/flamingo_web/live/game_live.ex
@@ -224,7 +224,7 @@ defmodule FlamingoWeb.GameLive do
               show_timer={@phase == :playing}
             />
 
-            <div class="flex w-full flex-1 flex-row gap-3 pb-1 pr-1">
+            <div class="flex min-h-0 w-full flex-1 flex-row gap-3 pb-1 pr-1">
               <.player_list_panel
                 players={@players}
                 player_order={@player_order}
@@ -363,7 +363,7 @@ defmodule FlamingoWeb.GameLive do
                   </div>
               <% end %>
 
-              <.box class="flex w-full flex-1 flex-col bg-white p-0">
+              <.box class="flex min-h-0 w-full flex-1 flex-col bg-white p-0">
                 <div
                   id="game-feed"
                   phx-hook=".ScrollFeed"


### PR DESCRIPTION
This fixes the in-game feed panel so it keeps a bounded height and scrolls instead of stretching the layout off screen. It adds the missing flex height constraints around the LiveView feed container in the Elixir UI. Validation: mix format lib/flamingo_web/live/game_live.ex and mix compile.