### PR TITLE
Freeze end-screen final scores

### DIFF
--- a/elixir/lib/flamingo_web/live/game_live.ex
+++ b/elixir/lib/flamingo_web/live/game_live.ex
@@ -19,6 +19,8 @@ defmodule FlamingoWeb.GameLive do
        phase: :lobby,
        players: %{},
        player_order: [],
+       final_players: %{},
+       final_player_order: [],
        host_id: nil,
        drawer_id: nil,
        round_count: 3,
@@ -56,6 +58,12 @@ defmodule FlamingoWeb.GameLive do
             score_gains =
               if state.phase == :turn_reveal, do: state.score_gains, else: %{}
 
+            final_players =
+              if state.phase == :game_ended, do: state.players, else: %{}
+
+            final_player_order =
+              if state.phase == :game_ended, do: state.player_order, else: []
+
             socket =
               assign(socket,
                 player_id: player_id,
@@ -64,6 +72,8 @@ defmodule FlamingoWeb.GameLive do
                 player_order: state.player_order,
                 host_id: state.host_id,
                 drawer_id: state.drawer_id,
+                final_players: final_players,
+                final_player_order: final_player_order,
                 round_count: state.round_count,
                 turn_length: state.turn_length,
                 current_round: state.current_round,
@@ -393,7 +403,7 @@ defmodule FlamingoWeb.GameLive do
           <.card class="flex w-full max-w-xs flex-col items-center gap-6 bg-white p-8">
             <h2 class="text-3xl font-bold">Game finished</h2>
             <ul class="w-full space-y-1">
-              <%= for {pid, idx} <- @player_order |> Enum.sort_by(fn pid -> -(Map.get(@players, pid).score) end) |> Enum.with_index() do %>
+              <%= for {pid, idx} <- @final_player_order |> Enum.sort_by(fn pid -> -(Map.get(@final_players, pid).score) end) |> Enum.with_index() do %>
                 <li class="flex items-center gap-2 px-3 py-2">
                   <span class="text-lg">
                     <%= case idx do %>
@@ -407,9 +417,9 @@ defmodule FlamingoWeb.GameLive do
                         {idx + 1}
                     <% end %>
                   </span>
-                  <span class="font-bold">{Map.get(@players, pid).name}</span>
+                  <span class="font-bold">{Map.get(@final_players, pid).name}</span>
                   <span class="ml-auto text-pink-500 font-semibold">
-                    {Map.get(@players, pid).score}
+                    {Map.get(@final_players, pid).score}
                   </span>
                 </li>
               <% end %>
@@ -538,7 +548,7 @@ defmodule FlamingoWeb.GameLive do
     socket = assign(socket, players: players, player_order: player_order, host_id: host_id)
 
     socket =
-      if new_count > old_count do
+      if socket.assigns.phase != :game_ended and new_count > old_count do
         push_event(socket, "play_sound", %{sound: "join"})
       else
         socket
@@ -562,6 +572,8 @@ defmodule FlamingoWeb.GameLive do
         round_count: round_count,
         turn_length: turn_length,
         current_round: current_round,
+        final_players: %{},
+        final_player_order: [],
         word_choices: if(is_drawer, do: word_choices, else: nil),
         word: nil,
         show_word: false,
@@ -580,6 +592,8 @@ defmodule FlamingoWeb.GameLive do
       assign(socket,
         phase: :playing,
         drawer_id: drawer_id,
+        final_players: %{},
+        final_player_order: [],
         word_choices: nil,
         turn_end_time: turn_end_time,
         word: word,
@@ -596,6 +610,8 @@ defmodule FlamingoWeb.GameLive do
     socket =
       assign(socket,
         phase: :turn_reveal,
+        final_players: %{},
+        final_player_order: [],
         word: word,
         show_word: true,
         turn_end_time: turn_end_time,
@@ -611,7 +627,8 @@ defmodule FlamingoWeb.GameLive do
     {:noreply,
      assign(socket,
        phase: :game_ended,
-       players: players,
+       final_players: players,
+       final_player_order: socket.assigns.player_order,
        turn_end_time: nil
      )}
   end

--- a/elixir/test/flamingo_web/live/game_live_test.exs
+++ b/elixir/test/flamingo_web/live/game_live_test.exs
@@ -1,0 +1,57 @@
+defmodule FlamingoWeb.GameLiveTest do
+  use FlamingoWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Flamingo.{GameServer, GameSupervisor}
+
+  setup do
+    room_id = "live-#{System.unique_integer([:positive])}"
+    {:ok, ^room_id} = GameSupervisor.start_game(room_id)
+    %{room_id: room_id}
+  end
+
+  test "game end screen keeps final scores visible after a player leaves", %{
+    conn: conn,
+    room_id: room_id
+  } do
+    {:ok, p1, _} = GameServer.join(room_id, "Alice")
+    {:ok, p2, _} = GameServer.join(room_id, "Bob")
+
+    {:ok, view, _html} = live(conn, ~p"/game/#{room_id}?player_id=#{p1}")
+
+    :ok = GameServer.start_game(room_id, p1, %{round_count: 1, turn_length: 30})
+
+    play_turn(room_id, p1, p2)
+    play_turn(room_id, p1, p2)
+
+    html = render(view)
+    assert html =~ "Game finished"
+    assert html =~ "Alice"
+    assert html =~ "Bob"
+
+    :ok = GameServer.leave(room_id, p2)
+
+    html = render(view)
+    assert html =~ "Game finished"
+    assert html =~ "Alice"
+    assert html =~ "Bob"
+  end
+
+  defp play_turn(room_id, p1, p2) do
+    {:ok, state} = GameServer.get_state(room_id)
+    word = List.first(state.word_choices)
+    :ok = GameServer.select_word(room_id, state.drawer_id, word)
+
+    {:ok, state} = GameServer.get_state(room_id)
+    guesser = if(p1 == state.drawer_id, do: p2, else: p1)
+    :correct = GameServer.guess(room_id, guesser, word)
+
+    pid = GenServer.whereis({:via, Registry, {Flamingo.GameRegistry, room_id}})
+    _ = :sys.get_state(pid)
+
+    {:ok, state} = GameServer.get_state(room_id)
+    send(pid, {:turn_reveal_timeout, state.phase_timer_ref})
+    _ = :sys.get_state(pid)
+  end
+end


### PR DESCRIPTION
This freezes the game-ended scoreboard in GameLive so it stops changing when players leave after the game is over. The end screen now renders from a LiveView snapshot taken when the game-ended event arrives, while live player updates still refresh the room state underneath. It also adds a LiveView regression test covering a player leaving after the end screen is shown.