### PR TITLE
Restore continuous game music

### DIFF
--- a/elixir/assets/js/hooks/sound_manager.ts
+++ b/elixir/assets/js/hooks/sound_manager.ts
@@ -45,7 +45,7 @@ const SoundManager = {
       if (!audio) return;
 
       audio.loop = true;
-      audio.currentTime = 0;
+      if (!audio.paused) return;
       audio.play().catch(() => {});
     });
 

--- a/elixir/lib/flamingo_web/live/game_live.ex
+++ b/elixir/lib/flamingo_web/live/game_live.ex
@@ -93,7 +93,10 @@ defmodule FlamingoWeb.GameLive do
                 socket
               end
 
-            socket = push_event(socket, "play_sound", %{sound: "join"})
+            socket =
+              socket
+              |> sync_game_music(state.phase)
+              |> push_event("play_sound", %{sound: "join"})
 
             {:noreply, socket}
           else
@@ -113,6 +116,14 @@ defmodule FlamingoWeb.GameLive do
   end
 
   defp palette, do: @palette
+
+  defp sync_game_music(socket, phase) when phase in [:word_choice, :playing, :turn_reveal] do
+    push_event(socket, "start_music", %{sound: "gameMusic"})
+  end
+
+  defp sync_game_music(socket, _phase) do
+    push_event(socket, "stop_music", %{sound: "gameMusic"})
+  end
 
   def render(assigns) do
     ~H"""
@@ -570,7 +581,7 @@ defmodule FlamingoWeb.GameLive do
       )
 
     socket = push_event(socket, "set_timer", %{end_time: DateTime.to_iso8601(turn_end_time)})
-    {:noreply, socket}
+    {:noreply, sync_game_music(socket, :word_choice)}
   end
 
   def handle_info({:turn_started, drawer_id, word, turn_end_time}, socket) do
@@ -589,7 +600,7 @@ defmodule FlamingoWeb.GameLive do
       )
 
     socket = push_event(socket, "set_timer", %{end_time: DateTime.to_iso8601(turn_end_time)})
-    {:noreply, socket}
+    {:noreply, sync_game_music(socket, :playing)}
   end
 
   def handle_info({:turn_reveal, word, turn_end_time, score_gains, players}, socket) do
@@ -604,16 +615,18 @@ defmodule FlamingoWeb.GameLive do
       )
 
     socket = push_event(socket, "set_timer", %{end_time: DateTime.to_iso8601(turn_end_time)})
-    {:noreply, socket}
+    {:noreply, sync_game_music(socket, :turn_reveal)}
   end
 
   def handle_info({:game_ended, players}, socket) do
     {:noreply,
-     assign(socket,
+     socket
+     |> assign(
        phase: :game_ended,
        players: players,
        turn_end_time: nil
-     )}
+     )
+     |> sync_game_music(:game_ended)}
   end
 
   def handle_info({:hint_revealed, revealed_indices}, socket) do


### PR DESCRIPTION
## Summary
Keep game music running across the full in-game flow by syncing LiveView music events for word choice, active turns, and turn reveal, while still stopping it in the lobby and on the game end screen.
Make the sound hook ignore redundant start requests so the track does not restart between phases or after reconnects.

## Validation
mix test
mix assets.build