### PR TITLE
Send private close-guess feedback

### DIFF
--- a/elixir/lib/flamingo/feed.ex
+++ b/elixir/lib/flamingo/feed.ex
@@ -23,6 +23,11 @@ defmodule Flamingo.Feed do
     {%{feed | events: feed.events ++ [event]}, event}
   end
 
+  def close_guess(feed, player_id) do
+    event = {:close_guess, player_id}
+    {%{feed | events: feed.events ++ [event]}, event}
+  end
+
   def correct_guess(feed, player_id, name) do
     event = {:correct_guess, player_id, name}
     {%{feed | events: feed.events ++ [event]}, event}
@@ -38,6 +43,11 @@ defmodule Flamingo.Feed do
 
   def format({:new_turn, _player_id, name}, _viewer), do: {:system, "It's #{name}'s turn to draw"}
   def format({:guess, _player_id, name, text}, _viewer), do: {:guess, "#{name}: #{text}"}
+
+  def format({:close_guess, player_id}, viewer) when player_id == viewer,
+    do: {:close, "You were close"}
+
+  def format({:close_guess, _player_id}, _viewer), do: nil
 
   def format({:correct_guess, player_id, _name}, viewer) when player_id == viewer,
     do: {:correct, "You guessed it"}

--- a/elixir/lib/flamingo/game_server.ex
+++ b/elixir/lib/flamingo/game_server.ex
@@ -190,6 +190,12 @@ defmodule Flamingo.GameServer do
         new_state = if all_guessed?, do: enter_turn_reveal(new_state), else: new_state
         {:reply, :correct, new_state}
 
+      close_guess?(text, state.word) ->
+        {feed, event} = Feed.close_guess(state.feed, player_id)
+        new_state = %{state | feed: feed}
+        broadcast(state.room_id, {:feed_event, event})
+        {:reply, :close, new_state}
+
       true ->
         player = Map.get(state.players, player_id)
         {feed, event} = Feed.guess(state.feed, player_id, player.name, text)
@@ -508,5 +514,28 @@ defmodule Flamingo.GameServer do
 
   defp broadcast(room_id, message) do
     Phoenix.PubSub.broadcast(Flamingo.PubSub, "game:#{room_id}", message)
+  end
+
+  defp close_guess?(guess, word) do
+    normalized_guess = normalize_guess(guess)
+    normalized_word = normalize_guess(word)
+
+    normalized_guess != normalized_word and
+      one_letter_different?(normalized_guess, normalized_word)
+  end
+
+  defp normalize_guess(text) do
+    text
+    |> String.downcase()
+    |> String.replace(~r/[^\p{L}\p{N}]/u, "")
+  end
+
+  defp one_letter_different?(left, right) do
+    left_chars = String.graphemes(left)
+    right_chars = String.graphemes(right)
+
+    length(left_chars) == length(right_chars) and
+      Enum.zip(left_chars, right_chars)
+      |> Enum.count(fn {left_char, right_char} -> left_char != right_char end) == 1
   end
 end

--- a/elixir/lib/flamingo_web/live/game_live.ex
+++ b/elixir/lib/flamingo_web/live/game_live.ex
@@ -84,7 +84,10 @@ defmodule FlamingoWeb.GameLive do
                 correct_guesses: MapSet.new(Map.keys(state.correct_guesses)),
                 revealed_indices: state.revealed_indices,
                 score_gains: score_gains,
-                feed: Enum.map(state.feed.events, &Feed.format(&1, player_id))
+                feed:
+                  state.feed.events
+                  |> Enum.map(&Feed.format(&1, player_id))
+                  |> Enum.reject(&is_nil/1)
               )
 
             socket =
@@ -385,6 +388,7 @@ defmodule FlamingoWeb.GameLive do
                       "p-1 text-xs",
                       type == :system && "font-semibold text-pink-600",
                       type == :correct && "font-semibold text-green-600",
+                      type == :close && "font-semibold text-amber-600",
                       type == :guess && "text-foreground",
                       type == :info && "text-gray-500"
                     ]}
@@ -669,10 +673,14 @@ defmodule FlamingoWeb.GameLive do
   def handle_info({:feed_event, event}, socket) do
     formatted = Feed.format(event, socket.assigns.player_id)
 
-    {:noreply,
-     socket
-     |> assign(:feed, socket.assigns.feed ++ [formatted])
-     |> push_event("scroll_feed", %{})}
+    if formatted do
+      {:noreply,
+       socket
+       |> assign(:feed, socket.assigns.feed ++ [formatted])
+       |> push_event("scroll_feed", %{})}
+    else
+      {:noreply, socket}
+    end
   end
 
   def handle_info({:draw_event, from_player_id, event}, socket) do

--- a/elixir/test/flamingo/game_server_test.exs
+++ b/elixir/test/flamingo/game_server_test.exs
@@ -145,6 +145,55 @@ defmodule Flamingo.GameServerTest do
     assert_receive {:incorrect_guess, ^guesser, "wrong-answer"}
   end
 
+  test "close guess sends private feedback instead of public chat", %{room_id: room_id} do
+    Phoenix.PubSub.subscribe(Flamingo.PubSub, "game:#{room_id}")
+    {p1, p2, word, state} = start_playing(room_id)
+    guesser = if p1 == state.drawer_id, do: p2, else: p1
+    other_player = if guesser == p1, do: p2, else: p1
+    close_guess = String.replace_suffix(word, String.last(word), "z")
+
+    assert :close = GameServer.guess(room_id, guesser, close_guess)
+
+    refute_receive {:incorrect_guess, ^guesser, ^close_guess}
+    assert_receive {:feed_event, {:close_guess, ^guesser} = event}
+
+    assert {:close, "You were close"} = Flamingo.Feed.format(event, guesser)
+    assert nil == Flamingo.Feed.format(event, other_player)
+  end
+
+  test "close guess ignores case spacing and punctuation for same-length typos", %{
+    room_id: room_id
+  } do
+    Phoenix.PubSub.subscribe(Flamingo.PubSub, "game:#{room_id}")
+    {p1, p2, word, state} = start_playing(room_id)
+    guesser = if p1 == state.drawer_id, do: p2, else: p1
+
+    close_guess =
+      word
+      |> String.replace_suffix(String.last(word), "z")
+      |> String.upcase()
+      |> String.graphemes()
+      |> Enum.join(" ")
+      |> Kernel.<>("!")
+
+    assert :close = GameServer.guess(room_id, guesser, close_guess)
+
+    refute_receive {:incorrect_guess, ^guesser, ^close_guess}
+    assert_receive {:feed_event, {:close_guess, ^guesser}}
+  end
+
+  test "wrong-length guesses are normal incorrect guesses", %{room_id: room_id} do
+    Phoenix.PubSub.subscribe(Flamingo.PubSub, "game:#{room_id}")
+    {p1, p2, word, state} = start_playing(room_id)
+    guesser = if p1 == state.drawer_id, do: p2, else: p1
+    wrong_length_guess = word <> "z"
+
+    assert :incorrect = GameServer.guess(room_id, guesser, wrong_length_guess)
+
+    assert_receive {:incorrect_guess, ^guesser, ^wrong_length_guess}
+    refute_receive {:feed_event, {:close_guess, ^guesser}}
+  end
+
   test "drawer cannot guess", %{room_id: room_id} do
     {_p1, _p2, word, state} = start_playing(room_id)
     assert {:error, :drawer_cannot_guess} = GameServer.guess(room_id, state.drawer_id, word)


### PR DESCRIPTION
## Summary
- detect same-length close guesses after case/space/punctuation normalization
- send private close-guess feed feedback instead of public incorrect-guess chat
- filter private feed events from other players and reconnect hydration

## Tests
- mix precommit