### PR TITLE
Show winner drawings in final results

### DIFF
--- a/elixir/assets/css/app.css
+++ b/elixir/assets/css/app.css
@@ -89,6 +89,14 @@
 
 [data-phx-session], [data-phx-teleported-src] { display: contents }
 
+.no-scrollbar {
+  scrollbar-width: none;
+}
+
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
 .grid-background {
   background-color: var(--color-pink-100);
   background-image: linear-gradient(90deg, #80808033 1px, #0000 0), linear-gradient(#80808033 1px, #0000 0);

--- a/elixir/assets/js/hooks/drawing_canvas.ts
+++ b/elixir/assets/js/hooks/drawing_canvas.ts
@@ -82,6 +82,12 @@ const DrawingCanvas = {
 
     canvasEffect(this.ctx, (imageData: ImageData) => clear(imageData));
 
+    if (this.el.dataset.finalDrawingEvents) {
+      const events = JSON.parse(this.el.dataset.finalDrawingEvents) as DrawEvent[];
+      this.eventStack = [...events];
+      replayEvents(this.ctx, events);
+    }
+
     if (this.isDrawer) {
       this.setupDrawerEvents();
       this.setupToolbar();

--- a/elixir/lib/flamingo/game_server.ex
+++ b/elixir/lib/flamingo/game_server.ex
@@ -23,6 +23,7 @@ defmodule Flamingo.GameServer do
     revealed_indices: [],
     hint_timer_ref: nil,
     score_gains: %{},
+    final_drawings: [],
     feed: Feed.new()
   ]
 
@@ -417,6 +418,7 @@ defmodule Flamingo.GameServer do
         phase_timer_ref: ref,
         turn_end_time: turn_end_time,
         drawn_this_round: MapSet.put(state.drawn_this_round, state.drawer_id),
+        final_drawings: state.final_drawings ++ [completed_drawing(state)],
         score_gains: score_gains,
         players: players
     }
@@ -465,8 +467,18 @@ defmodule Flamingo.GameServer do
         turn_end_time: nil
     }
 
-    broadcast(state.room_id, {:game_ended, state.players})
+    broadcast(state.room_id, {:game_ended, state.players, state.final_drawings})
     new_state
+  end
+
+  defp completed_drawing(state) do
+    %{
+      drawer_id: state.drawer_id,
+      word: state.word,
+      round_number: state.current_round + 1,
+      turn_order: length(state.final_drawings) + 1,
+      events: state.current_drawing
+    }
   end
 
   defp validate_host(state, player_id) do

--- a/elixir/lib/flamingo/game_server.ex
+++ b/elixir/lib/flamingo/game_server.ex
@@ -476,7 +476,6 @@ defmodule Flamingo.GameServer do
       drawer_id: state.drawer_id,
       word: state.word,
       round_number: state.current_round + 1,
-      turn_order: length(state.final_drawings) + 1,
       events: state.current_drawing
     }
   end

--- a/elixir/lib/flamingo_web/live/game_live.ex
+++ b/elixir/lib/flamingo_web/live/game_live.ex
@@ -142,7 +142,7 @@ defmodule FlamingoWeb.GameLive do
   defp drawings_for_player(final_drawings, player_id) do
     final_drawings
     |> Enum.filter(&(&1.drawer_id == player_id))
-    |> Enum.sort_by(& &1.turn_order)
+    |> Enum.sort_by(& &1.round_number)
   end
 
   defp sync_round_audio(socket) do
@@ -441,10 +441,9 @@ defmodule FlamingoWeb.GameLive do
       <%= if @phase == :game_ended do %>
         <.flamingo_background />
         <% winner_id = winning_player_id(@final_players, @final_player_order) %>
-        <% winner = winner_id && Map.get(@final_players, winner_id) %>
         <% winner_drawings = drawings_for_player(@final_drawings, winner_id) %>
-        <div class="flex h-screen w-full items-center justify-center p-6">
-          <div class="grid h-full w-full max-w-[1180px] grid-cols-[320px_minmax(0,1fr)] gap-6 py-8">
+        <div class="flex h-screen w-full items-center justify-center">
+          <div class="grid h-full w-fit grid-cols-[320px_320px] items-center justify-center gap-28">
             <.card class="flex h-fit w-full flex-col items-center gap-6 bg-white p-8">
               <h2 class="text-3xl font-bold">Game finished</h2>
               <ul class="w-full space-y-1">
@@ -471,38 +470,33 @@ defmodule FlamingoWeb.GameLive do
               </ul>
             </.card>
 
-            <div class="min-h-0 overflow-y-auto">
-              <div class="mb-4 flex items-end justify-between">
-                <div>
-                  <p class="text-sm font-bold uppercase tracking-wide text-pink-500">
-                    Winner showcase
-                  </p>
-                  <h3 class="text-3xl font-black">
-                    {if(winner, do: "#{winner.name}'s drawings", else: "Drawings")}
-                  </h3>
+            <div class="flex h-full min-h-0 flex-col">
+              <div class="no-scrollbar flex min-h-0 flex-1 flex-col overflow-y-auto pr-2 [justify-content:safe_center]">
+                <div class="flex w-full flex-col gap-4 py-4">
+                  <%= for drawing <- winner_drawings do %>
+                    <div class="border-2 border-border bg-white p-3">
+                      <div class="mb-2 flex items-center justify-between gap-3">
+                        <span
+                          class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-pink-400 text-xs font-black text-white"
+                          aria-label={"Round #{drawing.round_number}"}
+                        >
+                          {drawing.round_number}
+                        </span>
+                        <p class="truncate text-right font-bold">{drawing.word}</p>
+                      </div>
+                      <div
+                        id={"final-drawing-round-#{drawing.round_number}"}
+                        phx-hook="DrawingCanvas"
+                        phx-update="ignore"
+                        data-is-drawer="false"
+                        data-final-drawing-events={Jason.encode!(drawing.events)}
+                      >
+                        <canvas width="700" height="500" class="aspect-[7/5] w-full bg-white">
+                        </canvas>
+                      </div>
+                    </div>
+                  <% end %>
                 </div>
-              </div>
-
-              <div class="grid grid-cols-2 gap-4">
-                <%= for drawing <- winner_drawings do %>
-                  <.box class="bg-white p-3">
-                    <div class="mb-2 flex items-center justify-between gap-3">
-                      <p class="truncate font-bold">{drawing.word}</p>
-                      <span class="shrink-0 text-sm font-semibold text-pink-500">
-                        Round {drawing.round_number}
-                      </span>
-                    </div>
-                    <div
-                      id={"final-drawing-#{drawing.turn_order}"}
-                      phx-hook="DrawingCanvas"
-                      phx-update="ignore"
-                      data-is-drawer="false"
-                      data-final-drawing-events={Jason.encode!(drawing.events)}
-                    >
-                      <canvas width="700" height="500" class="aspect-[7/5] w-full bg-white"></canvas>
-                    </div>
-                  </.box>
-                <% end %>
               </div>
             </div>
           </div>

--- a/elixir/lib/flamingo_web/live/game_live.ex
+++ b/elixir/lib/flamingo_web/live/game_live.ex
@@ -21,6 +21,7 @@ defmodule FlamingoWeb.GameLive do
        player_order: [],
        final_players: %{},
        final_player_order: [],
+       final_drawings: [],
        host_id: nil,
        drawer_id: nil,
        round_count: 3,
@@ -64,6 +65,9 @@ defmodule FlamingoWeb.GameLive do
             final_player_order =
               if state.phase == :game_ended, do: state.player_order, else: []
 
+            final_drawings =
+              if state.phase == :game_ended, do: state.final_drawings, else: []
+
             socket =
               assign(socket,
                 player_id: player_id,
@@ -74,6 +78,7 @@ defmodule FlamingoWeb.GameLive do
                 drawer_id: state.drawer_id,
                 final_players: final_players,
                 final_player_order: final_player_order,
+                final_drawings: final_drawings,
                 round_count: state.round_count,
                 turn_length: state.turn_length,
                 current_round: state.current_round,
@@ -129,6 +134,16 @@ defmodule FlamingoWeb.GameLive do
   end
 
   defp palette, do: @palette
+
+  defp winning_player_id(players, player_order) do
+    Enum.max_by(player_order, fn pid -> Map.get(players, pid).score end, fn -> nil end)
+  end
+
+  defp drawings_for_player(final_drawings, player_id) do
+    final_drawings
+    |> Enum.filter(&(&1.drawer_id == player_id))
+    |> Enum.sort_by(& &1.turn_order)
+  end
 
   defp sync_round_audio(socket) do
     push_event(socket, "sync_round_audio", %{
@@ -425,32 +440,72 @@ defmodule FlamingoWeb.GameLive do
       <% end %>
       <%= if @phase == :game_ended do %>
         <.flamingo_background />
+        <% winner_id = winning_player_id(@final_players, @final_player_order) %>
+        <% winner = winner_id && Map.get(@final_players, winner_id) %>
+        <% winner_drawings = drawings_for_player(@final_drawings, winner_id) %>
         <div class="flex h-screen w-full items-center justify-center p-6">
-          <.card class="flex w-full max-w-xs flex-col items-center gap-6 bg-white p-8">
-            <h2 class="text-3xl font-bold">Game finished</h2>
-            <ul class="w-full space-y-1">
-              <%= for {pid, idx} <- @final_player_order |> Enum.sort_by(fn pid -> -(Map.get(@final_players, pid).score) end) |> Enum.with_index() do %>
-                <li class="flex items-center gap-2 px-3 py-2">
-                  <span class="text-lg">
-                    <%= case idx do %>
-                      <% 0 -> %>
-                        🥇
-                      <% 1 -> %>
-                        🥈
-                      <% 2 -> %>
-                        🥉
-                      <% _ -> %>
-                        {idx + 1}
-                    <% end %>
-                  </span>
-                  <span class="font-bold">{Map.get(@final_players, pid).name}</span>
-                  <span class="ml-auto text-pink-500 font-semibold">
-                    {Map.get(@final_players, pid).score}
-                  </span>
-                </li>
-              <% end %>
-            </ul>
-          </.card>
+          <div class="grid h-full w-full max-w-[1180px] grid-cols-[320px_minmax(0,1fr)] gap-6 py-8">
+            <.card class="flex h-fit w-full flex-col items-center gap-6 bg-white p-8">
+              <h2 class="text-3xl font-bold">Game finished</h2>
+              <ul class="w-full space-y-1">
+                <%= for {pid, idx} <- @final_player_order |> Enum.sort_by(fn pid -> -(Map.get(@final_players, pid).score) end) |> Enum.with_index() do %>
+                  <li class="flex items-center gap-2 px-3 py-2">
+                    <span class="text-lg">
+                      <%= case idx do %>
+                        <% 0 -> %>
+                          🥇
+                        <% 1 -> %>
+                          🥈
+                        <% 2 -> %>
+                          🥉
+                        <% _ -> %>
+                          {idx + 1}
+                      <% end %>
+                    </span>
+                    <span class="font-bold">{Map.get(@final_players, pid).name}</span>
+                    <span class="ml-auto text-pink-500 font-semibold">
+                      {Map.get(@final_players, pid).score}
+                    </span>
+                  </li>
+                <% end %>
+              </ul>
+            </.card>
+
+            <div class="min-h-0 overflow-y-auto">
+              <div class="mb-4 flex items-end justify-between">
+                <div>
+                  <p class="text-sm font-bold uppercase tracking-wide text-pink-500">
+                    Winner showcase
+                  </p>
+                  <h3 class="text-3xl font-black">
+                    {if(winner, do: "#{winner.name}'s drawings", else: "Drawings")}
+                  </h3>
+                </div>
+              </div>
+
+              <div class="grid grid-cols-2 gap-4">
+                <%= for drawing <- winner_drawings do %>
+                  <.box class="bg-white p-3">
+                    <div class="mb-2 flex items-center justify-between gap-3">
+                      <p class="truncate font-bold">{drawing.word}</p>
+                      <span class="shrink-0 text-sm font-semibold text-pink-500">
+                        Round {drawing.round_number}
+                      </span>
+                    </div>
+                    <div
+                      id={"final-drawing-#{drawing.turn_order}"}
+                      phx-hook="DrawingCanvas"
+                      phx-update="ignore"
+                      data-is-drawer="false"
+                      data-final-drawing-events={Jason.encode!(drawing.events)}
+                    >
+                      <canvas width="700" height="500" class="aspect-[7/5] w-full bg-white"></canvas>
+                    </div>
+                  </.box>
+                <% end %>
+              </div>
+            </div>
+          </div>
         </div>
       <% end %>
 
@@ -600,6 +655,7 @@ defmodule FlamingoWeb.GameLive do
         current_round: current_round,
         final_players: %{},
         final_player_order: [],
+        final_drawings: [],
         word_choices: if(is_drawer, do: word_choices, else: nil),
         word: nil,
         show_word: false,
@@ -624,6 +680,7 @@ defmodule FlamingoWeb.GameLive do
         drawer_id: drawer_id,
         final_players: %{},
         final_player_order: [],
+        final_drawings: [],
         word_choices: nil,
         turn_end_time: turn_end_time,
         word: word,
@@ -661,12 +718,13 @@ defmodule FlamingoWeb.GameLive do
     {:noreply, socket}
   end
 
-  def handle_info({:game_ended, players}, socket) do
+  def handle_info({:game_ended, players, final_drawings}, socket) do
     {:noreply,
      assign(socket,
        phase: :game_ended,
        final_players: players,
        final_player_order: socket.assigns.player_order,
+       final_drawings: final_drawings,
        turn_end_time: nil
      )
      |> sync_round_audio()}

--- a/elixir/test/flamingo/game_server_test.exs
+++ b/elixir/test/flamingo/game_server_test.exs
@@ -261,7 +261,6 @@ defmodule Flamingo.GameServerTest do
                drawer_id: ^drawer,
                word: ^word,
                round_number: 1,
-               turn_order: 1,
                events: [^start_event, ^draw_event]
              }
            ] = state.final_drawings
@@ -281,7 +280,6 @@ defmodule Flamingo.GameServerTest do
                drawer_id: ^drawer,
                word: ^word,
                round_number: 1,
-               turn_order: 1,
                events: []
              }
            ] = state.final_drawings

--- a/elixir/test/flamingo/game_server_test.exs
+++ b/elixir/test/flamingo/game_server_test.exs
@@ -227,6 +227,66 @@ defmodule Flamingo.GameServerTest do
     assert MapSet.member?(state.drawn_this_round, drawer)
   end
 
+  test "completed turn records drawing history", %{room_id: room_id} do
+    {p1, p2, word, state} = start_playing(room_id)
+    drawer = state.drawer_id
+    guesser = if p1 == drawer, do: p2, else: p1
+
+    start_event = %{
+      "event_type" => "start",
+      "x" => 10,
+      "y" => 20,
+      "color" => "#000000",
+      "line_width" => 9
+    }
+
+    draw_event = %{
+      "event_type" => "draw",
+      "start_x" => 10,
+      "start_y" => 20,
+      "end_x" => 30,
+      "end_y" => 40,
+      "color" => "#000000",
+      "line_width" => 9
+    }
+
+    GameServer.draw_event(room_id, drawer, start_event)
+    GameServer.draw_event(room_id, drawer, draw_event)
+    :correct = GameServer.guess(room_id, guesser, word)
+
+    {:ok, state} = GameServer.get_state(room_id)
+
+    assert [
+             %{
+               drawer_id: ^drawer,
+               word: ^word,
+               round_number: 1,
+               turn_order: 1,
+               events: [^start_event, ^draw_event]
+             }
+           ] = state.final_drawings
+  end
+
+  test "completed turn records empty drawing history", %{room_id: room_id} do
+    {p1, p2, word, state} = start_playing(room_id)
+    drawer = state.drawer_id
+    guesser = if p1 == drawer, do: p2, else: p1
+
+    :correct = GameServer.guess(room_id, guesser, word)
+
+    {:ok, state} = GameServer.get_state(room_id)
+
+    assert [
+             %{
+               drawer_id: ^drawer,
+               word: ^word,
+               round_number: 1,
+               turn_order: 1,
+               events: []
+             }
+           ] = state.final_drawings
+  end
+
   test "game ends after all players draw in all rounds", %{room_id: room_id} do
     Phoenix.PubSub.subscribe(Flamingo.PubSub, "game:#{room_id}")
 
@@ -263,7 +323,7 @@ defmodule Flamingo.GameServerTest do
 
     {:ok, state} = GameServer.get_state(room_id)
     assert state.phase == :game_ended
-    assert_receive {:game_ended, _players}
+    assert_receive {:game_ended, _players, _final_drawings}
   end
 
   test "round increments after all players draw", %{room_id: room_id} do

--- a/elixir/test/flamingo_web/live/game_live_test.exs
+++ b/elixir/test/flamingo_web/live/game_live_test.exs
@@ -38,6 +38,42 @@ defmodule FlamingoWeb.GameLiveTest do
     assert html =~ "Bob"
   end
 
+  test "game end screen shows the winning player's drawings", %{conn: conn, room_id: room_id} do
+    {:ok, p1, _} = GameServer.join(room_id, "Alice")
+    {:ok, p2, _} = GameServer.join(room_id, "Bob")
+
+    {:ok, view, _html} = live(conn, ~p"/game/#{room_id}?player_id=#{p1}")
+
+    :ok = GameServer.start_game(room_id, p1, %{round_count: 1, turn_length: 30})
+
+    words_by_player =
+      play_turn(room_id, p1, p2, [
+        %{
+          "event_type" => "start",
+          "x" => 10,
+          "y" => 20,
+          "color" => "#000000",
+          "line_width" => 9
+        }
+      ])
+      |> then(&%{p1 => &1})
+
+    words_by_player = Map.put(words_by_player, p2, play_turn(room_id, p1, p2, []))
+
+    {:ok, state} = GameServer.get_state(room_id)
+    winner_id = Enum.max_by(state.player_order, fn pid -> Map.get(state.players, pid).score end)
+    winner = Map.get(state.players, winner_id)
+    winner_word = Map.get(words_by_player, winner_id)
+
+    html = render(view)
+
+    assert html =~ "Game finished"
+    assert html =~ "#{winner.name}&#39;s drawings"
+    assert html =~ "Round 1"
+    assert html =~ winner_word
+    assert html =~ "data-final-drawing-events="
+  end
+
   test "pushes round audio lifecycle events as phases change", %{conn: conn, room_id: room_id} do
     {:ok, p1, _} = GameServer.join(room_id, "Alice")
     {:ok, p2, _} = GameServer.join(room_id, "Bob")
@@ -76,12 +112,13 @@ defmodule FlamingoWeb.GameLiveTest do
     assert is_binary(reveal_end_time)
   end
 
-  defp play_turn(room_id, p1, p2) do
+  defp play_turn(room_id, p1, p2, drawing_events \\ []) do
     {:ok, state} = GameServer.get_state(room_id)
     word = List.first(state.word_choices)
     :ok = GameServer.select_word(room_id, state.drawer_id, word)
 
     {:ok, state} = GameServer.get_state(room_id)
+    Enum.each(drawing_events, &GameServer.draw_event(room_id, state.drawer_id, &1))
     guesser = if(p1 == state.drawer_id, do: p2, else: p1)
     :correct = GameServer.guess(room_id, guesser, word)
 
@@ -91,5 +128,7 @@ defmodule FlamingoWeb.GameLiveTest do
     {:ok, state} = GameServer.get_state(room_id)
     send(pid, {:turn_reveal_timeout, state.phase_timer_ref})
     _ = :sys.get_state(pid)
+
+    word
   end
 end

--- a/elixir/test/flamingo_web/live/game_live_test.exs
+++ b/elixir/test/flamingo_web/live/game_live_test.exs
@@ -68,8 +68,8 @@ defmodule FlamingoWeb.GameLiveTest do
     html = render(view)
 
     assert html =~ "Game finished"
-    assert html =~ "#{winner.name}&#39;s drawings"
-    assert html =~ "Round 1"
+    assert html =~ winner.name
+    assert html =~ "aria-label=\"Round 1\""
     assert html =~ winner_word
     assert html =~ "data-final-drawing-events="
   end


### PR DESCRIPTION
## Summary
- record completed turn drawing history with drawer, word, round, turn order, and events
- render the winning player's final drawing showcase alongside final scores