### PR TITLE
Keep departed players in final game results

### DIFF
--- a/elixir/lib/flamingo/game_server.ex
+++ b/elixir/lib/flamingo/game_server.ex
@@ -24,6 +24,7 @@ defmodule Flamingo.GameServer do
     hint_timer_ref: nil,
     score_gains: %{},
     final_drawings: [],
+    departed_player_ids: MapSet.new(),
     feed: Feed.new()
   ]
 
@@ -106,7 +107,16 @@ defmodule Flamingo.GameServer do
 
   def handle_call({:rejoin, player_id}, _from, state) do
     if Map.has_key?(state.players, player_id) do
-      {:reply, {:ok, state}, state}
+      new_state = %{
+        state
+        | departed_player_ids: MapSet.delete(state.departed_player_ids, player_id)
+      }
+
+      if MapSet.member?(state.departed_player_ids, player_id) do
+        broadcast_active_players(new_state)
+      end
+
+      {:reply, {:ok, new_state}, new_state}
     else
       {:reply, {:error, :not_found}, state}
     end
@@ -165,7 +175,7 @@ defmodule Flamingo.GameServer do
       state.phase != :playing ->
         {:reply, {:error, :not_playing}, state}
 
-      not Map.has_key?(state.players, player_id) ->
+      not active_player?(state, player_id) ->
         {:reply, {:error, :not_found}, state}
 
       player_id == state.drawer_id ->
@@ -183,7 +193,9 @@ defmodule Flamingo.GameServer do
         broadcast(state.room_id, {:feed_event, event})
 
         non_drawers =
-          Enum.reject(state.player_order, &(&1 == state.drawer_id))
+          state
+          |> active_player_order()
+          |> Enum.reject(&(&1 == state.drawer_id))
 
         all_guessed? =
           Enum.all?(non_drawers, &Map.has_key?(correct_guesses, &1))
@@ -212,16 +224,32 @@ defmodule Flamingo.GameServer do
   end
 
   def handle_call({:leave, player_id}, _from, state) do
-    if not Map.has_key?(state.players, player_id) do
+    if not active_player?(state, player_id) do
       {:reply, :ok, state}
     else
       player_name = Map.get(state.players, player_id).name
-      players = Map.delete(state.players, player_id)
-      player_order = List.delete(state.player_order, player_id)
+      lobby? = state.phase == :lobby
+
+      players =
+        if lobby?,
+          do: Map.delete(state.players, player_id),
+          else: state.players
+
+      player_order =
+        if lobby?,
+          do: List.delete(state.player_order, player_id),
+          else: state.player_order
+
+      departed_player_ids =
+        if lobby?,
+          do: state.departed_player_ids,
+          else: MapSet.put(state.departed_player_ids, player_id)
+
+      active_player_order = active_player_order(player_order, departed_player_ids)
 
       host_id =
         if state.host_id == player_id,
-          do: List.first(player_order),
+          do: List.first(active_player_order),
           else: state.host_id
 
       correct_guesses = Map.delete(state.correct_guesses, player_id)
@@ -230,6 +258,7 @@ defmodule Flamingo.GameServer do
         state
         | players: players,
           player_order: player_order,
+          departed_player_ids: departed_player_ids,
           host_id: host_id,
           correct_guesses: correct_guesses
       }
@@ -237,16 +266,13 @@ defmodule Flamingo.GameServer do
       {feed, event} = Feed.player_left(new_state.feed, player_id, player_name)
       new_state = %{new_state | feed: feed}
 
-      broadcast(
-        state.room_id,
-        {:players_updated, new_state.players, new_state.player_order, new_state.host_id}
-      )
+      broadcast_active_players(new_state)
 
       broadcast(state.room_id, {:feed_event, event})
 
       new_state =
         if state.phase == :playing and player_id != state.drawer_id do
-          non_drawers = Enum.reject(player_order, &(&1 == state.drawer_id))
+          non_drawers = Enum.reject(active_player_order, &(&1 == state.drawer_id))
 
           if non_drawers != [] and
                Enum.all?(non_drawers, &Map.has_key?(correct_guesses, &1)) do
@@ -402,7 +428,7 @@ defmodule Flamingo.GameServer do
       Flamingo.Scoring.calculate_round_scores(
         state.correct_guesses,
         state.drawer_id,
-        state.player_order,
+        active_player_order(state),
         state.turn_length
       )
 
@@ -435,7 +461,7 @@ defmodule Flamingo.GameServer do
     state = %{state | score_gains: %{}}
 
     next_drawer =
-      Enum.find(state.player_order, fn pid ->
+      Enum.find(active_player_order(state), fn pid ->
         not MapSet.member?(state.drawn_this_round, pid)
       end)
 
@@ -452,7 +478,7 @@ defmodule Flamingo.GameServer do
           state
           | current_round: new_round,
             drawn_this_round: MapSet.new(),
-            drawer_id: List.first(state.player_order)
+            drawer_id: List.first(active_player_order(state))
         }
         |> enter_word_choice()
       end
@@ -469,6 +495,31 @@ defmodule Flamingo.GameServer do
 
     broadcast(state.room_id, {:game_ended, state.players, state.final_drawings})
     new_state
+  end
+
+  defp active_player?(state, player_id) do
+    Map.has_key?(state.players, player_id) and
+      not MapSet.member?(state.departed_player_ids, player_id)
+  end
+
+  defp active_players(state) do
+    state.players
+    |> Map.take(active_player_order(state))
+  end
+
+  defp active_player_order(state) do
+    active_player_order(state.player_order, state.departed_player_ids)
+  end
+
+  defp active_player_order(player_order, departed_player_ids) do
+    Enum.reject(player_order, &MapSet.member?(departed_player_ids, &1))
+  end
+
+  defp broadcast_active_players(state) do
+    broadcast(
+      state.room_id,
+      {:players_updated, active_players(state), active_player_order(state), state.host_id}
+    )
   end
 
   defp completed_drawing(state) do

--- a/elixir/lib/flamingo_web/live/game_live.ex
+++ b/elixir/lib/flamingo_web/live/game_live.ex
@@ -19,6 +19,7 @@ defmodule FlamingoWeb.GameLive do
        phase: :lobby,
        players: %{},
        player_order: [],
+       participant_order: [],
        final_players: %{},
        final_player_order: [],
        final_drawings: [],
@@ -80,6 +81,7 @@ defmodule FlamingoWeb.GameLive do
                 phase: state.phase,
                 players: state.players,
                 player_order: state.player_order,
+                participant_order: state.player_order,
                 host_id: state.host_id,
                 drawer_id: state.drawer_id,
                 final_players: final_players,
@@ -662,7 +664,25 @@ defmodule FlamingoWeb.GameLive do
     old_count = map_size(socket.assigns.players)
     new_count = map_size(players)
 
-    socket = assign(socket, players: players, player_order: player_order, host_id: host_id)
+    players =
+      if socket.assigns.phase == :turn_reveal do
+        Map.merge(socket.assigns.players, players)
+      else
+        players
+      end
+
+    participant_order =
+      socket.assigns.participant_order
+      |> merge_player_order(socket.assigns.player_order)
+      |> merge_player_order(player_order)
+
+    socket =
+      assign(socket,
+        players: players,
+        player_order: player_order,
+        participant_order: participant_order,
+        host_id: host_id
+      )
 
     socket =
       if socket.assigns.phase != :game_ended and new_count > old_count do
@@ -746,7 +766,9 @@ defmodule FlamingoWeb.GameLive do
         show_word: true,
         turn_end_time: turn_end_time,
         score_gains: score_gains,
-        players: players
+        players: players,
+        participant_order:
+          merge_player_order(socket.assigns.participant_order, socket.assigns.player_order)
       )
 
     socket =
@@ -758,7 +780,10 @@ defmodule FlamingoWeb.GameLive do
   end
 
   def handle_info({:game_ended, players, final_drawings}, socket) do
-    final_player_order = socket.assigns.player_order
+    final_player_order =
+      socket.assigns.participant_order
+      |> merge_player_order(socket.assigns.player_order)
+      |> Enum.filter(&Map.has_key?(players, &1))
 
     {:noreply,
      assign(socket,
@@ -830,5 +855,11 @@ defmodule FlamingoWeb.GameLive do
     if Map.has_key?(socket.assigns, :room_id) and Map.has_key?(socket.assigns, :player_id) do
       Games.leave(socket.assigns.room_id, socket.assigns.player_id)
     end
+  end
+
+  defp merge_player_order(left, right) do
+    Enum.reduce(right, left, fn pid, order ->
+      if pid in order, do: order, else: order ++ [pid]
+    end)
   end
 end

--- a/elixir/test/flamingo/game_server_test.exs
+++ b/elixir/test/flamingo/game_server_test.exs
@@ -324,6 +324,54 @@ defmodule Flamingo.GameServerTest do
     assert_receive {:game_ended, _players, _final_drawings}
   end
 
+  test "departed players stay in final results but are skipped as future drawers", %{
+    room_id: room_id
+  } do
+    {:ok, p1, _} = GameServer.join(room_id, "Alice")
+    {:ok, p2, _} = GameServer.join(room_id, "Bob")
+    {:ok, p3, _} = GameServer.join(room_id, "Charlie")
+    :ok = GameServer.start_game(room_id, p1, %{round_count: 1, turn_length: 30})
+
+    pid = GenServer.whereis({:via, Registry, {Flamingo.GameRegistry, room_id}})
+
+    {:ok, state} = GameServer.get_state(room_id)
+    assert state.drawer_id == p1
+    word = List.first(state.word_choices)
+    :ok = GameServer.select_word(room_id, p1, word)
+
+    start_event = %{
+      "event_type" => "start",
+      "x" => 10,
+      "y" => 20,
+      "color" => "#000000",
+      "line_width" => 9
+    }
+
+    GameServer.draw_event(room_id, p1, start_event)
+    :correct = GameServer.guess(room_id, p2, word)
+    :correct = GameServer.guess(room_id, p3, word)
+
+    {:ok, state} = GameServer.get_state(room_id)
+    alice_score = Map.fetch!(state.players, p1).score
+    assert alice_score > 0
+
+    :ok = GameServer.leave(room_id, p1)
+    send(pid, {:turn_reveal_timeout, state.phase_timer_ref})
+    _ = :sys.get_state(pid)
+
+    {:ok, state} = GameServer.get_state(room_id)
+    assert state.phase == :word_choice
+    assert state.drawer_id == p2
+
+    play_current_turn(room_id, p3)
+    play_current_turn(room_id, p2)
+
+    {:ok, state} = GameServer.get_state(room_id)
+    assert state.phase == :game_ended
+    assert Map.fetch!(state.players, p1).score == alice_score
+    assert Enum.any?(state.final_drawings, &(&1.drawer_id == p1 and &1.events == [start_event]))
+  end
+
   test "round increments after all players draw", %{room_id: room_id} do
     {:ok, p1, _} = GameServer.join(room_id, "Alice")
     {:ok, p2, _} = GameServer.join(room_id, "Bob")
@@ -397,5 +445,17 @@ defmodule Flamingo.GameServerTest do
 
     {:ok, state} = GameServer.get_state(room_id)
     assert state.phase == :playing
+  end
+
+  defp play_current_turn(room_id, guesser) do
+    pid = GenServer.whereis({:via, Registry, {Flamingo.GameRegistry, room_id}})
+    {:ok, state} = GameServer.get_state(room_id)
+    word = List.first(state.word_choices)
+    :ok = GameServer.select_word(room_id, state.drawer_id, word)
+    :correct = GameServer.guess(room_id, guesser, word)
+
+    {:ok, state} = GameServer.get_state(room_id)
+    send(pid, {:turn_reveal_timeout, state.phase_timer_ref})
+    _ = :sys.get_state(pid)
   end
 end

--- a/elixir/test/flamingo_web/live/game_live_test.exs
+++ b/elixir/test/flamingo_web/live/game_live_test.exs
@@ -38,6 +38,50 @@ defmodule FlamingoWeb.GameLiveTest do
     assert html =~ "Bob"
   end
 
+  test "game end screen keeps players who left mid-game", %{
+    conn: conn,
+    room_id: room_id
+  } do
+    {:ok, p1, _} = GameServer.join(room_id, "Alice")
+    {:ok, p2, _} = GameServer.join(room_id, "Bob")
+    {:ok, p3, _} = GameServer.join(room_id, "Charlie")
+
+    {:ok, view, _html} = live(conn, ~p"/game/#{room_id}?player_id=#{p2}")
+
+    :ok = GameServer.start_game(room_id, p1, %{round_count: 1, turn_length: 30})
+
+    alice_word =
+      play_turn_for_guessers(room_id, [p2, p3], [
+        %{
+          "event_type" => "start",
+          "x" => 10,
+          "y" => 20,
+          "color" => "#000000",
+          "line_width" => 9
+        }
+      ])
+
+    :ok = GameServer.leave(room_id, p1)
+    advance_reveal(room_id)
+
+    play_turn_for_guessers(room_id, [p3])
+    advance_reveal(room_id)
+    play_turn_for_guessers(room_id, [p2])
+    advance_reveal(room_id)
+
+    html = render(view)
+    assert html =~ "Game finished"
+    assert html =~ "Alice"
+
+    html =
+      view
+      |> element("[data-player-id='#{p1}']")
+      |> render_click()
+
+    assert html =~ alice_word
+    assert html =~ "final-drawing-#{p1}-round-1"
+  end
+
   test "game end screen shows the winning player's drawings", %{conn: conn, room_id: room_id} do
     {:ok, p1, _} = GameServer.join(room_id, "Alice")
     {:ok, p2, _} = GameServer.join(room_id, "Bob")
@@ -203,5 +247,24 @@ defmodule FlamingoWeb.GameLiveTest do
     _ = :sys.get_state(pid)
 
     word
+  end
+
+  defp play_turn_for_guessers(room_id, guessers, drawing_events \\ []) do
+    {:ok, state} = GameServer.get_state(room_id)
+    word = List.first(state.word_choices)
+    :ok = GameServer.select_word(room_id, state.drawer_id, word)
+
+    {:ok, state} = GameServer.get_state(room_id)
+    Enum.each(drawing_events, &GameServer.draw_event(room_id, state.drawer_id, &1))
+    Enum.each(guessers, &assert(:correct = GameServer.guess(room_id, &1, word)))
+
+    word
+  end
+
+  defp advance_reveal(room_id) do
+    pid = GenServer.whereis({:via, Registry, {Flamingo.GameRegistry, room_id}})
+    {:ok, state} = GameServer.get_state(room_id)
+    send(pid, {:turn_reveal_timeout, state.phase_timer_ref})
+    _ = :sys.get_state(pid)
   end
 end


### PR DESCRIPTION
## Summary
- keep in-game departed players in GameServer final participant state while excluding them from active player broadcasts, guessing, scoring, and future drawer selection
- preserve participant ordering in GameLive so departed players remain selectable on final results
- add GameServer and LiveView regressions for mid-game departures retaining scores and drawings

## Tests
- mix precommit