### PR TITLE
Add replay for final drawing showcase

### DIFF
--- a/elixir/assets/js/app.js
+++ b/elixir/assets/js/app.js
@@ -25,6 +25,7 @@ import {LiveSocket} from "phoenix_live_view"
 import {hooks as colocatedHooks} from "phoenix-colocated/flamingo"
 import topbar from "../vendor/topbar"
 import DrawingCanvas from "./hooks/drawing_canvas"
+import FinalDrawingShowcase from "./hooks/final_drawing_showcase"
 import SoundManager from "./hooks/sound_manager"
 
 window.__soundMuted = localStorage.getItem("flamingo_sound_muted") === "true"
@@ -33,7 +34,7 @@ const csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute
 const liveSocket = new LiveSocket("/live", Socket, {
   longPollFallbackMs: 2500,
   params: {_csrf_token: csrfToken},
-  hooks: {...colocatedHooks, DrawingCanvas, SoundManager},
+  hooks: {...colocatedHooks, DrawingCanvas, FinalDrawingShowcase, SoundManager},
 })
 
 // Show progress bar on live navigation and form submits
@@ -84,4 +85,3 @@ if (process.env.NODE_ENV === "development") {
     window.liveReloader = reloader
   })
 }
-

--- a/elixir/assets/js/hooks/drawing_canvas.ts
+++ b/elixir/assets/js/hooks/drawing_canvas.ts
@@ -14,6 +14,32 @@ interface Point {
   y: number;
 }
 
+type ActiveTool = "pen" | "fill";
+
+interface DrawingCanvasHook {
+  el: HTMLElement;
+  canvas: HTMLCanvasElement;
+  ctx: CanvasRenderingContext2D;
+  isDrawer: boolean;
+  isPainting: boolean;
+  lastCoord: Point | null;
+  selectedColor: string;
+  selectedThickness: number;
+  activeTool: ActiveTool;
+  eventStack: DrawEvent[];
+  redoStack: DrawEvent[][];
+  finalReplayToken: number;
+  replayFinalDrawingListener?: () => void;
+  handleEvent: <T>(event: string, callback: (payload: T) => void) => void;
+  pushEvent: (event: string, payload: DrawEvent) => void;
+  replayFinalDrawing: () => void;
+  setupDrawerEvents: () => void;
+  setupToolbar: () => void;
+  performUndo: () => void;
+  performRedo: () => void;
+  performClear: () => void;
+}
+
 const isUndoBoundary = (type: string) =>
   type === "start" || type === "fill" || type === "clear";
 
@@ -44,13 +70,42 @@ const renderDrawEvent = (imageData: ImageData, event: DrawEvent) => {
   }
 };
 
-const replayEvents = (ctx: CanvasRenderingContext2D, events: DrawEvent[]) => {
+const renderEvents = (ctx: CanvasRenderingContext2D, events: DrawEvent[]) => {
   canvasEffect(ctx, (imageData) => {
     clear(imageData);
     for (const e of events) {
       renderDrawEvent(imageData, e);
     }
   });
+};
+
+const replayEvents = (
+  ctx: CanvasRenderingContext2D,
+  events: DrawEvent[],
+  isCurrentReplay: () => boolean,
+  delayMs = 15
+) => {
+  canvasEffect(ctx, (imageData) => clear(imageData));
+
+  if (events.length === 0) return;
+
+  let index = 0;
+
+  const renderNext = () => {
+    if (!isCurrentReplay()) return;
+
+    canvasEffect(ctx, (imageData) => {
+      renderDrawEvent(imageData, events[index]);
+    });
+
+    index += 1;
+
+    if (index < events.length) {
+      window.setTimeout(renderNext, delayMs);
+    }
+  };
+
+  window.setTimeout(renderNext, delayMs);
 };
 
 const findUndoBoundaryIndex = (events: DrawEvent[]): number => {
@@ -68,7 +123,7 @@ const translatePointerToCanvas = (e: PointerEvent, canvas: HTMLCanvasElement): [
 };
 
 const DrawingCanvas = {
-  mounted(this: any) {
+  mounted(this: DrawingCanvasHook) {
     this.canvas = this.el.querySelector("canvas") as HTMLCanvasElement;
     this.ctx = this.canvas.getContext("2d", { willReadFrequently: true })!;
     this.isDrawer = this.el.dataset.isDrawer === "true";
@@ -76,16 +131,17 @@ const DrawingCanvas = {
     this.lastCoord = null as Point | null;
     this.selectedColor = "#000000";
     this.selectedThickness = 9;
-    this.activeTool = "pen" as "pen" | "fill";
+    this.activeTool = "pen";
     this.eventStack = [] as DrawEvent[];
     this.redoStack = [] as DrawEvent[][];
+    this.finalReplayToken = 0;
 
     canvasEffect(this.ctx, (imageData: ImageData) => clear(imageData));
 
     if (this.el.dataset.finalDrawingEvents) {
       const events = JSON.parse(this.el.dataset.finalDrawingEvents) as DrawEvent[];
       this.eventStack = [...events];
-      replayEvents(this.ctx, events);
+      this.replayFinalDrawing();
     }
 
     if (this.isDrawer) {
@@ -101,7 +157,7 @@ const DrawingCanvas = {
         if (idx >= 0) {
           this.eventStack.splice(idx);
         }
-        replayEvents(this.ctx, this.eventStack);
+        renderEvents(this.ctx, this.eventStack);
         return;
       }
 
@@ -113,11 +169,29 @@ const DrawingCanvas = {
 
     this.handleEvent("drawing_state", (data: { events: DrawEvent[] }) => {
       this.eventStack = [...data.events];
-      replayEvents(this.ctx, data.events);
+      renderEvents(this.ctx, data.events);
     });
+
+    this.replayFinalDrawingListener = () => {
+      this.replayFinalDrawing();
+    };
+    window.addEventListener("flamingo:replay-final-drawings", this.replayFinalDrawingListener);
   },
 
-  setupDrawerEvents(this: any) {
+  replayFinalDrawing(this: DrawingCanvasHook) {
+    if (this.el.dataset.finalDrawingReplay !== "true") return;
+
+    this.finalReplayToken += 1;
+    const token = this.finalReplayToken;
+
+    replayEvents(
+      this.ctx,
+      this.eventStack,
+      () => this.finalReplayToken === token
+    );
+  },
+
+  setupDrawerEvents(this: DrawingCanvasHook) {
     const canvas = this.canvas as HTMLCanvasElement;
 
     const pushDrawEvent = (event: DrawEvent) => {
@@ -198,17 +272,17 @@ const DrawingCanvas = {
     });
   },
 
-  performUndo(this: any) {
+  performUndo(this: DrawingCanvasHook) {
     const idx = findUndoBoundaryIndex(this.eventStack);
     if (idx < 0) return;
 
     const removed = this.eventStack.splice(idx);
     this.redoStack.push(removed);
-    replayEvents(this.ctx, this.eventStack);
+    renderEvents(this.ctx, this.eventStack);
     this.pushEvent("draw_event", { event_type: "undo" });
   },
 
-  performRedo(this: any) {
+  performRedo(this: DrawingCanvasHook) {
     if (this.redoStack.length === 0) return;
 
     const restored = this.redoStack.pop()!;
@@ -216,10 +290,10 @@ const DrawingCanvas = {
       this.eventStack.push(event);
       this.pushEvent("draw_event", event);
     }
-    replayEvents(this.ctx, this.eventStack);
+    renderEvents(this.ctx, this.eventStack);
   },
 
-  performClear(this: any) {
+  performClear(this: DrawingCanvasHook) {
     const clearEvent: DrawEvent = { event_type: "clear" };
     this.eventStack.push(clearEvent);
     this.redoStack = [];
@@ -227,7 +301,7 @@ const DrawingCanvas = {
     this.pushEvent("draw_event", clearEvent);
   },
 
-  setupToolbar(this: any) {
+  setupToolbar(this: DrawingCanvasHook) {
     const selectGroup = (attr: string, ringClasses: string[], onSelect: (value: string) => void) => {
       this.el.querySelectorAll(`[${attr}]`).forEach((btn: HTMLElement) => {
         btn.addEventListener("click", () => {
@@ -259,6 +333,14 @@ const DrawingCanvas = {
     this.el.querySelector(`[data-color="#000000"]`)?.classList.add("ring-2", "ring-offset-1");
     this.el.querySelector(`[data-size="9"]`)?.classList.add("bg-pink-300");
     this.el.querySelector(`[data-tool="pen"]`)?.classList.add("bg-pink-300");
+  },
+
+  destroyed(this: DrawingCanvasHook) {
+    this.finalReplayToken += 1;
+
+    if (this.replayFinalDrawingListener) {
+      window.removeEventListener("flamingo:replay-final-drawings", this.replayFinalDrawingListener);
+    }
   },
 };
 

--- a/elixir/assets/js/hooks/final_drawing_showcase.ts
+++ b/elixir/assets/js/hooks/final_drawing_showcase.ts
@@ -1,0 +1,38 @@
+interface FinalDrawingShowcaseHook {
+  el: HTMLElement;
+  selectedPlayerId?: string;
+  replayFinalDrawings: () => void;
+  replay: () => void;
+}
+
+const FinalDrawingShowcase = {
+  mounted(this: FinalDrawingShowcaseHook) {
+    this.selectedPlayerId = this.el.dataset.selectedPlayerId;
+    this.replayFinalDrawings = () => {
+      window.dispatchEvent(new Event("flamingo:replay-final-drawings"));
+    };
+
+    this.el.addEventListener("click", (event: MouseEvent) => {
+      if ((event.target as HTMLElement).closest("[data-replay-final-drawings]")) {
+        this.replay();
+      }
+    });
+
+    this.replay();
+  },
+
+  updated(this: FinalDrawingShowcaseHook) {
+    const selectedPlayerId = this.el.dataset.selectedPlayerId;
+
+    if (selectedPlayerId !== this.selectedPlayerId) {
+      this.selectedPlayerId = selectedPlayerId;
+      this.replay();
+    }
+  },
+
+  replay(this: FinalDrawingShowcaseHook) {
+    window.setTimeout(this.replayFinalDrawings, 0);
+  },
+};
+
+export default FinalDrawingShowcase;

--- a/elixir/assets/js/hooks/sound_manager.ts
+++ b/elixir/assets/js/hooks/sound_manager.ts
@@ -2,6 +2,15 @@ type SoundKey = "join" | "correct" | "gameMusic" | "wrongGuess" | "correctGuess"
 
 import type { GamePhase } from "../game_model";
 
+interface SoundManagerHook {
+  sounds: Record<SoundKey, HTMLAudioElement>;
+  fadeTimers: Partial<Record<SoundKey, number>>;
+  countdownTimer: number | null;
+  countdownTurnEndTime: string | null;
+  stopAllAudio?: () => void;
+  handleEvent: <T>(event: string, callback: (payload: T) => void) => void;
+}
+
 const SOUND_FILES: Record<SoundKey, string> = {
   join: "/sounds/retro-join.wav",
   correct: "/sounds/correct-tone.wav",
@@ -13,7 +22,7 @@ const SOUND_FILES: Record<SoundKey, string> = {
 };
 
 const SoundManager = {
-  mounted(this: any) {
+  mounted(this: SoundManagerHook) {
     this.sounds = {} as Record<SoundKey, HTMLAudioElement>;
     this.fadeTimers = {} as Partial<Record<SoundKey, number>>;
     this.countdownTimer = null as number | null;
@@ -190,7 +199,7 @@ const SoundManager = {
     };
   },
 
-  destroyed(this: any) {
+  destroyed(this: SoundManagerHook) {
     if (this.stopAllAudio) {
       this.stopAllAudio();
     }

--- a/elixir/lib/flamingo_web/live/game_live.ex
+++ b/elixir/lib/flamingo_web/live/game_live.ex
@@ -466,15 +466,22 @@ defmodule FlamingoWeb.GameLive do
           <div class="grid h-full w-fit grid-cols-[320px_320px] items-center justify-center gap-28">
             <.card class="flex h-fit w-full flex-col items-center gap-6 bg-white p-8">
               <h2 class="text-3xl font-bold">Game finished</h2>
-              <ul class="w-full space-y-1">
+              <ul
+                id="final-score-rows"
+                class="w-full space-y-1"
+                phx-hook="FinalDrawingShowcase"
+                data-selected-player-id={selected_player_id}
+              >
                 <%= for {pid, idx} <- @final_player_order |> Enum.sort_by(fn pid -> -(Map.get(@final_players, pid).score) end) |> Enum.with_index() do %>
-                  <li>
+                  <li class={[
+                    "flex items-center transition-colors",
+                    pid == selected_player_id && "bg-pink-100",
+                    pid != selected_player_id && "hover:bg-pink-50"
+                  ]}>
                     <button
                       type="button"
                       class={[
-                        "flex w-full items-center gap-2 px-3 py-2 text-left transition-colors",
-                        pid == selected_player_id && "bg-pink-100",
-                        pid != selected_player_id && "hover:bg-pink-50"
+                        "flex min-w-0 flex-1 items-center gap-2 px-3 py-2 text-left"
                       ]}
                       phx-click="select_player"
                       phx-value-player-id={pid}
@@ -498,6 +505,16 @@ defmodule FlamingoWeb.GameLive do
                         {Map.get(@final_players, pid).score}
                       </span>
                     </button>
+                    <button
+                      :if={pid == selected_player_id}
+                      type="button"
+                      class="mr-2 flex h-8 w-8 shrink-0 items-center justify-center text-pink-600 transition-colors hover:bg-pink-200"
+                      data-replay-final-drawings
+                      aria-label="Replay selected drawings"
+                    >
+                      <.icon name="arrows_clockwise" class="h-4 w-4" />
+                    </button>
+                    <span :if={pid != selected_player_id} class="mr-2 h-8 w-8 shrink-0"></span>
                   </li>
                 <% end %>
               </ul>
@@ -527,6 +544,7 @@ defmodule FlamingoWeb.GameLive do
                         phx-hook="DrawingCanvas"
                         phx-update="ignore"
                         data-is-drawer="false"
+                        data-final-drawing-replay="true"
                         data-final-drawing-events={Jason.encode!(drawing.events)}
                       >
                         <canvas width="700" height="500" class="aspect-[7/5] w-full bg-white">

--- a/elixir/test/flamingo_web/live/game_live_test.exs
+++ b/elixir/test/flamingo_web/live/game_live_test.exs
@@ -72,6 +72,7 @@ defmodule FlamingoWeb.GameLiveTest do
     assert html =~ "aria-label=\"Round 1\""
     assert html =~ winner_word
     assert html =~ "data-final-drawing-events="
+    assert html =~ "data-final-drawing-replay=\"true\""
   end
 
   test "final score rows select the drawing showcase", %{
@@ -119,6 +120,26 @@ defmodule FlamingoWeb.GameLiveTest do
     assert html =~ bob_word
     assert html =~ "final-drawing-#{p2}-round-1"
     assert html =~ "data-selected=\"true\""
+  end
+
+  test "selected final score row has a client-side replay control", %{
+    conn: conn,
+    room_id: room_id
+  } do
+    {:ok, p1, _} = GameServer.join(room_id, "Alice")
+    {:ok, p2, _} = GameServer.join(room_id, "Bob")
+
+    {:ok, view, _html} = live(conn, ~p"/game/#{room_id}?player_id=#{p1}")
+
+    :ok = GameServer.start_game(room_id, p1, %{round_count: 1, turn_length: 30})
+    play_turn(room_id, p1, p2, [])
+    play_turn(room_id, p1, p2, [])
+
+    html = render(view)
+
+    assert html =~ "aria-label=\"Replay selected drawings\""
+    assert html =~ "data-replay-final-drawings"
+    refute html =~ "phx-click=\"replay_final_drawings\""
   end
 
   test "final score row with no drawings remains selectable and shows an empty state", %{


### PR DESCRIPTION
## Summary
- Add client-side replay for final showcase drawings when the final screen loads, the selected player changes, or the replay control is pressed