### PR TITLE
Allow manual Fly deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 jobs:
   deploy:
     name: Deploy app


### PR DESCRIPTION
## Summary
- add workflow_dispatch to the Fly Deploy workflow so deploys can be run manually from GitHub Actions

## Verification
- inspected .github/workflows/deploy.yml diff