### PR TITLE
Install flyctl directly in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,10 @@ jobs:
     concurrency: deploy-group
     steps:
       - uses: actions/checkout@v4
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - name: Install flyctl
+        run: |
+          curl -L https://fly.io/install.sh | sh
+          echo "$HOME/.fly/bin" >> "$GITHUB_PATH"
       - run: flyctl deploy --remote-only
         working-directory: ./elixir
         env:


### PR DESCRIPTION
## Summary
- replace the superfly/flyctl-actions setup step with direct flyctl installation
- keep the manual workflow trigger and existing deploy command

## Why
GitHub failed before deploy while downloading the flyctl action archive from codeload.github.com. Installing flyctl directly avoids that action archive fetch path.

## Verification
- inspected .github/workflows/deploy.yml diff