### PR TITLE
Fix final page replay icon

### DIFF
--- a/elixir/lib/flamingo_web/live/game_live.ex
+++ b/elixir/lib/flamingo_web/live/game_live.ex
@@ -512,7 +512,7 @@ defmodule FlamingoWeb.GameLive do
                       data-replay-final-drawings
                       aria-label="Replay selected drawings"
                     >
-                      <.icon name="arrows_clockwise" class="h-4 w-4" />
+                      <.icon name={:refresh_cw} class="h-4 w-4" />
                     </button>
                     <span :if={pid != selected_player_id} class="mr-2 h-8 w-8 shrink-0"></span>
                   </li>


### PR DESCRIPTION
## Summary
- update the final page replay button to pass the Lucide icon atom directly