### PR TITLE
Treat one-character insertions and deletions as close guesses

### DIFF
--- a/lib/flamingo/game_server.ex
+++ b/lib/flamingo/game_server.ex
@@ -532,7 +532,7 @@ defmodule Flamingo.GameServer do
     normalized_word = normalize_guess(word)
 
     normalized_guess != normalized_word and
-      one_letter_different?(normalized_guess, normalized_word)
+      one_edit_different?(normalized_guess, normalized_word)
   end
 
   defp normalize_guess(text) do
@@ -541,12 +541,34 @@ defmodule Flamingo.GameServer do
     |> String.replace(~r/[^\p{L}\p{N}]/u, "")
   end
 
-  defp one_letter_different?(left, right) do
+  defp one_edit_different?(left, right) do
     left_chars = String.graphemes(left)
     right_chars = String.graphemes(right)
 
-    length(left_chars) == length(right_chars) and
-      Enum.zip(left_chars, right_chars)
-      |> Enum.count(fn {left_char, right_char} -> left_char != right_char end) == 1
+    cond do
+      length(left_chars) == length(right_chars) ->
+        one_substitution?(left_chars, right_chars)
+
+      length(left_chars) + 1 == length(right_chars) ->
+        one_insert_or_delete?(left_chars, right_chars)
+
+      length(left_chars) == length(right_chars) + 1 ->
+        one_insert_or_delete?(right_chars, left_chars)
+
+      true ->
+        false
+    end
+  end
+
+  defp one_substitution?(left_chars, right_chars) do
+    left_chars
+    |> Enum.zip(right_chars)
+    |> Enum.count(fn {left_char, right_char} -> left_char != right_char end) == 1
+  end
+
+  defp one_insert_or_delete?(shorter_chars, longer_chars) do
+    Enum.any?(0..length(longer_chars), fn index ->
+      List.delete_at(longer_chars, index) == shorter_chars
+    end)
   end
 end

--- a/test/flamingo/game_server_test.exs
+++ b/test/flamingo/game_server_test.exs
@@ -186,12 +186,36 @@ defmodule Flamingo.GameServerTest do
     Phoenix.PubSub.subscribe(Flamingo.PubSub, "game:#{room_id}")
     {p1, p2, word, state} = start_playing(room_id)
     guesser = if p1 == state.drawer_id, do: p2, else: p1
-    wrong_length_guess = word <> "z"
+    wrong_length_guess = word <> "zz"
 
     assert :incorrect = GameServer.guess(room_id, guesser, wrong_length_guess)
 
     assert_receive {:incorrect_guess, ^guesser, ^wrong_length_guess}
     refute_receive {:feed_event, {:close_guess, ^guesser}}
+  end
+
+  test "one-character insertion is a close guess", %{room_id: room_id} do
+    Phoenix.PubSub.subscribe(Flamingo.PubSub, "game:#{room_id}")
+    {p1, p2, word, state} = start_playing(room_id)
+    guesser = if p1 == state.drawer_id, do: p2, else: p1
+    close_guess = word <> "z"
+
+    assert :close = GameServer.guess(room_id, guesser, close_guess)
+
+    refute_receive {:incorrect_guess, ^guesser, ^close_guess}
+    assert_receive {:feed_event, {:close_guess, ^guesser}}
+  end
+
+  test "one-character deletion is a close guess", %{room_id: room_id} do
+    Phoenix.PubSub.subscribe(Flamingo.PubSub, "game:#{room_id}")
+    {p1, p2, word, state} = start_playing(room_id)
+    guesser = if p1 == state.drawer_id, do: p2, else: p1
+    close_guess = String.slice(word, 0, String.length(word) - 1)
+
+    assert :close = GameServer.guess(room_id, guesser, close_guess)
+
+    refute_receive {:incorrect_guess, ^guesser, ^close_guess}
+    assert_receive {:feed_event, {:close_guess, ^guesser}}
   end
 
   test "drawer cannot guess", %{room_id: room_id} do


### PR DESCRIPTION
Close-guess feedback currently covers one wrong character after normalization, but guesses with one extra or missing character are treated as ordinary incorrect guesses. This expands the same close-feedback path to one inserted or deleted normalized grapheme while preserving exact matches as correct guesses and keeping guesses more than one edit away incorrect.

The matcher stays deliberately narrow rather than introducing a general edit-distance dependency.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #157
- <kbd>&nbsp;1&nbsp;</kbd> #155 👈 
<!-- GitButler Footer Boundary Bottom -->