### PR TITLE
Scroll Feed to bottom after phase changes

### DIFF
--- a/lib/flamingo_web/live/game_live.ex
+++ b/lib/flamingo_web/live/game_live.ex
@@ -666,12 +666,13 @@ defmodule FlamingoWeb.GameLive do
       <script :type={Phoenix.LiveView.ColocatedHook} name=".ScrollFeed">
         export default {
           mounted() {
-            this.el.scrollTop = this.el.scrollHeight
-            this.handleEvent("scroll_feed", () => {
-              this.el.scrollTop = this.el.scrollHeight
-            })
+            this.scrollToBottom()
+            this.handleEvent("scroll_feed", () => this.scrollToBottom())
           },
           updated() {
+            this.scrollToBottom()
+          },
+          scrollToBottom() {
             this.el.scrollTop = this.el.scrollHeight
           }
         }


### PR DESCRIPTION
Feed scroll behavior is intentionally simple: whenever LiveView updates the Feed container, including phase changes, the colocated hook scrolls it to the bottom. Server-triggered Feed events continue to request the same bottom-scroll behavior.

This removes the previous scroll-position snapshot and restoration logic.