### PR TITLE
Exclude used words from later choices

### DIFF
--- a/lib/flamingo/game_server.ex
+++ b/lib/flamingo/game_server.ex
@@ -19,6 +19,7 @@ defmodule Flamingo.GameServer do
     drawn_this_round: MapSet.new(),
     current_drawing: [],
     word_choices: [],
+    used_words: MapSet.new(),
     correct_guesses: %{},
     revealed_indices: [],
     hint_timer_ref: nil,
@@ -133,7 +134,9 @@ defmodule Flamingo.GameServer do
             turn_length: turn_length,
             drawer_id: drawer_id,
             current_round: 0,
-            drawn_this_round: MapSet.new()
+            drawn_this_round: MapSet.new(),
+            used_words: MapSet.new(),
+            final_drawings: []
         }
         |> enter_word_choice()
 
@@ -338,7 +341,16 @@ defmodule Flamingo.GameServer do
   end
 
   defp enter_word_choice(state) do
-    word_choices = Flamingo.Words.random_choices()
+    word_choices = Flamingo.Words.random_choices(3, state.used_words)
+
+    if word_choices == [] do
+      enter_game_ended(state)
+    else
+      start_word_choice(state, word_choices)
+    end
+  end
+
+  defp start_word_choice(state, word_choices) do
     ref = make_ref()
     Process.send_after(self(), {:word_choice_timeout, ref}, 10_000)
     turn_end_time = DateTime.add(DateTime.utc_now(), 10, :second)
@@ -380,6 +392,7 @@ defmodule Flamingo.GameServer do
       state
       | phase: :playing,
         word: word,
+        used_words: MapSet.put(state.used_words, word),
         word_choices: [],
         phase_timer_ref: ref,
         turn_end_time: turn_end_time,

--- a/lib/flamingo/words.ex
+++ b/lib/flamingo/words.ex
@@ -2,7 +2,9 @@ defmodule Flamingo.Words do
   @words File.read!("priv/words/default.txt")
          |> String.split("\n", trim: true)
 
-  def random_choices(n \\ 3) do
-    Enum.take_random(@words, n)
+  def random_choices(n \\ 3, excluded_words \\ MapSet.new()) do
+    @words
+    |> Enum.reject(&MapSet.member?(excluded_words, &1))
+    |> Enum.take_random(n)
   end
 end

--- a/test/flamingo/game_server_test.exs
+++ b/test/flamingo/game_server_test.exs
@@ -378,6 +378,68 @@ defmodule Flamingo.GameServerTest do
     assert state.drawn_this_round == MapSet.new()
   end
 
+  test "selected words are excluded from later choices in the same game", %{room_id: room_id} do
+    {:ok, p1, _} = GameServer.join(room_id, "Alice")
+    {:ok, p2, _} = GameServer.join(room_id, "Bob")
+    :ok = GameServer.start_game(room_id, p1, %{round_count: 1, turn_length: 30})
+
+    pid = GenServer.whereis({:via, Registry, {Flamingo.GameRegistry, room_id}})
+
+    {:ok, state} = GameServer.get_state(room_id)
+    word = List.first(state.word_choices)
+    :ok = GameServer.select_word(room_id, state.drawer_id, word)
+
+    {:ok, state} = GameServer.get_state(room_id)
+    guesser = if p1 == state.drawer_id, do: p2, else: p1
+    :correct = GameServer.guess(room_id, guesser, word)
+
+    {:ok, state} = GameServer.get_state(room_id)
+    assert MapSet.member?(state.used_words, word)
+
+    send(pid, {:turn_reveal_timeout, state.phase_timer_ref})
+    _ = :sys.get_state(pid)
+
+    {:ok, state} = GameServer.get_state(room_id)
+    refute word in state.word_choices
+  end
+
+  test "used word history resets when a new game starts", %{room_id: room_id} do
+    {:ok, p1, _} = GameServer.join(room_id, "Alice")
+    {:ok, p2, _} = GameServer.join(room_id, "Bob")
+    :ok = GameServer.start_game(room_id, p1, %{round_count: 1, turn_length: 30})
+
+    pid = GenServer.whereis({:via, Registry, {Flamingo.GameRegistry, room_id}})
+
+    play_turn = fn ->
+      {:ok, state} = GameServer.get_state(room_id)
+      word = List.first(state.word_choices)
+      :ok = GameServer.select_word(room_id, state.drawer_id, word)
+
+      {:ok, state} = GameServer.get_state(room_id)
+      guesser = if p1 == state.drawer_id, do: p2, else: p1
+      :correct = GameServer.guess(room_id, guesser, word)
+
+      {:ok, state} = GameServer.get_state(room_id)
+      send(pid, {:turn_reveal_timeout, state.phase_timer_ref})
+      _ = :sys.get_state(pid)
+
+      word
+    end
+
+    first_word = play_turn.()
+    play_turn.()
+
+    {:ok, state} = GameServer.get_state(room_id)
+    assert state.phase == :game_ended
+    assert MapSet.member?(state.used_words, first_word)
+
+    :ok = GameServer.start_game(room_id, p1, %{round_count: 1, turn_length: 30})
+
+    {:ok, state} = GameServer.get_state(room_id)
+    assert state.phase == :word_choice
+    assert state.used_words == MapSet.new()
+  end
+
   test "leave during playing reconciles turn completion", %{room_id: room_id} do
     {:ok, p1, _} = GameServer.join(room_id, "Alice")
     {:ok, p2, _} = GameServer.join(room_id, "Bob")

--- a/test/flamingo/words_test.exs
+++ b/test/flamingo/words_test.exs
@@ -1,0 +1,26 @@
+defmodule Flamingo.WordsTest do
+  use ExUnit.Case, async: true
+
+  alias Flamingo.Words
+
+  test "random_choices returns expected number of unused words when enough remain" do
+    words = all_words()
+    excluded_words = words |> Enum.drop(3) |> MapSet.new()
+
+    choices = Words.random_choices(3, excluded_words)
+
+    assert length(choices) == 3
+    assert Enum.all?(choices, &(not MapSet.member?(excluded_words, &1)))
+  end
+
+  test "random_choices handles exhausted unused words" do
+    excluded_words = MapSet.new(all_words())
+    assert Words.random_choices(3, excluded_words) == []
+  end
+
+  defp all_words do
+    "priv/words/default.txt"
+    |> File.read!()
+    |> String.split("\n", trim: true)
+  end
+end


### PR DESCRIPTION
Players should not see a word again after it has already been selected in the current game, so the game now tracks selected words and filters them out of future choice sets.

The history resets when a new game starts in the same room. If the unused pool is exhausted unexpectedly, the game ends instead of entering an empty word-choice phase.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #157 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #155
<!-- GitButler Footer Boundary Bottom -->