### PR TITLE
Fix production deploy after Elixir 1.20 upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ npm-debug.log
 /assets/node_modules/
 
 .DS_Store
+
+/notes/

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,13 @@
 # This file is based on these images:
 #
 #   - https://hub.docker.com/r/hexpm/elixir/tags - for the build image
-#   - https://hub.docker.com/_/debian/tags?name=trixie-20260223-slim - for the release image
+#   - https://hub.docker.com/_/debian/tags?name=trixie-20260518-slim - for the release image
 #   - https://pkgs.org/ - resource for finding needed packages
-#   - Ex: docker.io/hexpm/elixir:1.19.1-erlang-28.1.1-debian-trixie-20260223-slim
+#   - Ex: docker.io/hexpm/elixir:1.20.0-erlang-28.1.1-debian-trixie-20260518-slim
 #
-ARG ELIXIR_VERSION=1.19.1
+ARG ELIXIR_VERSION=1.20.0
 ARG OTP_VERSION=28.1.1
-ARG DEBIAN_VERSION=trixie-20260223-slim
+ARG DEBIAN_VERSION=trixie-20260518-slim
 
 ARG BUILDER_IMAGE="docker.io/hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="docker.io/debian:${DEBIAN_VERSION}"

--- a/test/flamingo/deployment_test.exs
+++ b/test/flamingo/deployment_test.exs
@@ -1,0 +1,12 @@
+defmodule Flamingo.DeploymentTest do
+  use ExUnit.Case, async: true
+
+  test "Docker builder uses a supported Elixir version" do
+    dockerfile = File.read!(Path.expand("../../Dockerfile", __DIR__))
+    [_, docker_elixir_version] = Regex.run(~r/^ARG ELIXIR_VERSION=(\S+)$/m, dockerfile)
+    required_elixir_version = Mix.Project.config() |> Keyword.fetch!(:elixir)
+
+    assert Version.match?(docker_elixir_version, required_elixir_version),
+           "Docker uses Elixir #{docker_elixir_version}, but mix.exs requires #{required_elixir_version}"
+  end
+end


### PR DESCRIPTION
The Elixir 1.20 upgrade raised the project requirement but left Fly's Docker builder on Elixir 1.19.1, causing production builds to stop at `mix assets.setup`.

Align the production image with the project requirement and guard against future drift. The Debian snapshot also moves forward because the Elixir 1.20 image is not available against the previous February snapshot; OTP remains on 28.1.1.