### PR TITLE
Replace sound toggle with volume slider

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -29,7 +29,17 @@ import FinalDrawingShowcase from "./hooks/final_drawing_showcase"
 import SharedDrawing from "./hooks/shared_drawing"
 import SoundManager from "./hooks/sound_manager"
 
-window.__soundMuted = localStorage.getItem("flamingo_sound_muted") === "true"
+const clampStoredSoundVolume = (value) => {
+  const volume = Number.parseInt(value, 10)
+  if (!Number.isFinite(volume)) return 100
+  return Math.min(100, Math.max(0, volume))
+}
+
+const storedSoundVolume = localStorage.getItem("flamingo_sound_volume")
+window.__soundVolume = storedSoundVolume === null
+  ? (localStorage.getItem("flamingo_sound_muted") === "true" ? 0 : 100)
+  : clampStoredSoundVolume(storedSoundVolume)
+window.__soundMuted = window.__soundVolume === 0
 
 const csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
 const liveSocket = new LiveSocket("/live", Socket, {

--- a/assets/js/global.d.ts
+++ b/assets/js/global.d.ts
@@ -3,5 +3,6 @@ export {};
 declare global {
   interface Window {
     __soundMuted: boolean;
+    __soundVolume: number;
   }
 }

--- a/assets/js/hooks/sound_manager.ts
+++ b/assets/js/hooks/sound_manager.ts
@@ -21,12 +21,29 @@ const SOUND_FILES: Record<SoundKey, string> = {
   countdown: "/sounds/countdown.mp3",
 };
 
+const MUSIC_VOLUME = 0.08;
+const COUNTDOWN_VOLUME = 0.7;
+const EFFECT_VOLUME = 1;
+
+type RoundAudioPayload = { phase: GamePhase; end_time?: string | null };
+
 const SoundManager = {
   mounted(this: SoundManagerHook) {
     this.sounds = {} as Record<SoundKey, HTMLAudioElement>;
     this.fadeTimers = {} as Partial<Record<SoundKey, number>>;
     this.countdownTimer = null as number | null;
-    this.countdownTurnEndTime = null as number | null;
+    this.countdownTurnEndTime = null as string | null;
+
+    const masterVolume = () => {
+      const volume = Number.isFinite(window.__soundVolume) ? window.__soundVolume : 100;
+      return Math.min(100, Math.max(0, volume)) / 100;
+    };
+
+    const volumeLevel = (baseVolume: number) => baseVolume * masterVolume();
+
+    const soundIsMuted = () => masterVolume() === 0;
+    let wasMuted = soundIsMuted();
+    let lastRoundAudio: RoundAudioPayload | null = null;
 
     const clearFade = (sound: SoundKey) => {
       const timer = this.fadeTimers[sound];
@@ -51,7 +68,7 @@ const SoundManager = {
     };
 
     const fadeInMusic = () => {
-      if (window.__soundMuted) return;
+      if (soundIsMuted()) return;
       const audio = this.sounds.gameMusic;
       if (!audio) return;
 
@@ -64,8 +81,9 @@ const SoundManager = {
       }
 
       this.fadeTimers.gameMusic = window.setInterval(() => {
-        audio.volume = Math.min(0.08, audio.volume + 0.01);
-        if (audio.volume >= 0.08) {
+        const targetVolume = volumeLevel(MUSIC_VOLUME);
+        audio.volume = Math.min(targetVolume, audio.volume + 0.01);
+        if (audio.volume >= targetVolume) {
           clearFade("gameMusic");
         }
       }, 80);
@@ -90,12 +108,12 @@ const SoundManager = {
     };
 
     const startCountdown = () => {
-      if (window.__soundMuted) return;
+      if (soundIsMuted()) return;
       const audio = this.sounds.countdown;
       if (!audio || !audio.paused) return;
 
       audio.currentTime = 0;
-      audio.volume = 0.7;
+      audio.volume = volumeLevel(COUNTDOWN_VOLUME);
       audio.play().catch(() => {});
     };
 
@@ -119,7 +137,7 @@ const SoundManager = {
       }, countdownStartDelay);
     };
 
-    const syncRoundAudio = ({ phase, end_time }: { phase: GamePhase; end_time?: string | null }) => {
+    const applyRoundAudio = ({ phase, end_time }: RoundAudioPayload) => {
       if (phase === "playing" && end_time) {
         fadeInMusic();
         scheduleCountdown(end_time);
@@ -130,6 +148,11 @@ const SoundManager = {
       stopCountdown();
     };
 
+    const syncRoundAudio = (payload: RoundAudioPayload) => {
+      lastRoundAudio = payload;
+      applyRoundAudio(payload);
+    };
+
     const keys = ["join", "correct", "gameMusic", "wrongGuess", "correctGuess", "otherPlayerCorrect", "countdown"] as SoundKey[];
     for (const key of keys) {
       const audio = new Audio(SOUND_FILES[key]);
@@ -137,7 +160,7 @@ const SoundManager = {
       this.sounds[key] = audio;
     }
 
-    window.addEventListener("flamingo:mute", () => {
+    const stopAllAudio = () => {
       if (this.countdownTimer !== null) {
         window.clearTimeout(this.countdownTimer);
         this.countdownTimer = null;
@@ -152,25 +175,54 @@ const SoundManager = {
         audio.currentTime = 0;
         audio.loop = false;
       }
+    };
+
+    window.addEventListener("flamingo:volumechange", () => {
+      if (soundIsMuted()) {
+        stopAllAudio();
+        wasMuted = true;
+        return;
+      }
+
+      if (wasMuted && lastRoundAudio) {
+        stopAllAudio();
+        wasMuted = false;
+        applyRoundAudio(lastRoundAudio);
+        return;
+      }
+
+      wasMuted = false;
+
+      const music = this.sounds.gameMusic;
+      if (music && !music.paused) {
+        music.volume = volumeLevel(MUSIC_VOLUME);
+      }
+
+      const countdown = this.sounds.countdown;
+      if (countdown && !countdown.paused) {
+        countdown.volume = volumeLevel(COUNTDOWN_VOLUME);
+      }
     });
 
     this.handleEvent("play_sound", ({ sound }: { sound: SoundKey }) => {
-      if (window.__soundMuted) return;
+      if (soundIsMuted()) return;
       const audio = this.sounds[sound];
       if (!audio) return;
 
       audio.currentTime = 0;
+      audio.volume = volumeLevel(EFFECT_VOLUME);
       audio.play().catch(() => {});
     });
 
     this.handleEvent("start_music", ({ sound }: { sound: SoundKey }) => {
-      if (window.__soundMuted) return;
+      if (soundIsMuted()) return;
       const audio = this.sounds[sound];
       if (!audio) return;
 
       clearFade(sound);
       audio.loop = true;
       audio.currentTime = 0;
+      audio.volume = volumeLevel(sound === "gameMusic" ? MUSIC_VOLUME : EFFECT_VOLUME);
       audio.play().catch(() => {});
     });
 

--- a/lib/flamingo/game_server.ex
+++ b/lib/flamingo/game_server.ex
@@ -77,7 +77,7 @@ defmodule Flamingo.GameServer do
     :exit, {:noproc, _} -> {:error, :not_found}
   end
 
-  defp first_hint_delay_ms(turn_length) do
+  def first_hint_delay_ms(turn_length) do
     min(@hint_interval_ms, max(1_000, turn_length * 1000 - @hint_before_turn_end_ms))
   end
 

--- a/lib/flamingo_web/components/layouts.ex
+++ b/lib/flamingo_web/components/layouts.ex
@@ -16,27 +16,110 @@ defmodule FlamingoWeb.Layouts do
     <.flash_group flash={@flash} />
     <div id="sound-manager" phx-hook="SoundManager" phx-update="ignore"></div>
     <div
-      id="sound-toggle"
-      phx-hook=".SoundToggle"
+      id="sound-volume-control"
+      phx-hook=".SoundVolume"
       phx-update="ignore"
-      class="fixed bottom-4 left-4 z-50"
+      class="fixed bottom-4 left-4 z-50 rounded-base border-2 border-border bg-white px-3 py-2 shadow-shadow"
     >
-      <.switch id="sound-toggle-switch" label="Play sounds" />
+      <div class="flex items-center gap-2">
+        <button
+          type="button"
+          id="sound-volume-button"
+          aria-label="Toggle sound mute"
+          class="flex size-5 shrink-0 cursor-pointer items-center justify-center text-foreground"
+        >
+          <span class="sr-only">Toggle sound mute</span>
+          <span
+            id="sound-volume-icon"
+            class="flex size-5 shrink-0 items-center justify-center text-foreground"
+            aria-hidden="true"
+          >
+            <span data-sound-volume-icon="muted" class="hidden">
+              <.icon name={:volume_x} class="size-5" />
+            </span>
+            <span data-sound-volume-icon="low" class="hidden">
+              <.icon name={:volume} class="size-5" />
+            </span>
+            <span data-sound-volume-icon="medium" class="hidden">
+              <.icon name={:volume_1} class="size-5" />
+            </span>
+            <span data-sound-volume-icon="high"><.icon name={:volume_2} class="size-5" /></span>
+          </span>
+        </button>
+        <label for="sound-volume-slider" class="sr-only">Sound volume</label>
+        <input
+          type="range"
+          id="sound-volume-slider"
+          min="0"
+          max="100"
+          step="1"
+          value="100"
+          aria-label="Sound volume"
+          class="nb-slider w-28"
+          style="--slider-progress: 100%"
+        />
+      </div>
     </div>
-    <script :type={Phoenix.LiveView.ColocatedHook} name=".SoundToggle">
+    <script :type={Phoenix.LiveView.ColocatedHook} name=".SoundVolume">
       export default {
         mounted() {
-          const checkbox = this.el.querySelector("#sound-toggle-switch");
-          const muted = localStorage.getItem("flamingo_sound_muted") === "true";
-          window.__soundMuted = muted;
-          checkbox.checked = !muted;
+          const slider = this.el.querySelector("#sound-volume-slider");
+          const muteButton = this.el.querySelector("#sound-volume-button");
+          const icons = Array.from(this.el.querySelectorAll("[data-sound-volume-icon]"));
 
-          checkbox.addEventListener("change", () => {
-            window.__soundMuted = !checkbox.checked;
+          const clampVolume = (value) => {
+            const volume = Number.parseInt(value, 10);
+            if (!Number.isFinite(volume)) return 100;
+            return Math.min(100, Math.max(0, volume));
+          };
+
+          const storedPreviousVolume = () => {
+            const previous = clampVolume(localStorage.getItem("flamingo_sound_previous_volume"));
+            return previous === 0 ? 100 : previous;
+          };
+
+          const storedVolume = () => {
+            const stored = localStorage.getItem("flamingo_sound_volume");
+            if (stored !== null) return clampVolume(stored);
+            return localStorage.getItem("flamingo_sound_muted") === "true" ? 0 : 100;
+          };
+
+          const iconForVolume = (volume) => {
+            if (volume === 0) return "muted";
+            if (volume <= 33) return "low";
+            if (volume <= 66) return "medium";
+            return "high";
+          };
+
+          const applyVolume = (volume) => {
+            const clampedVolume = clampVolume(volume);
+            const visibleIcon = iconForVolume(clampedVolume);
+
+            slider.value = clampedVolume;
+            slider.style.setProperty("--slider-progress", `${clampedVolume}%`);
+            window.__soundVolume = clampedVolume;
+            window.__soundMuted = clampedVolume === 0;
+            localStorage.setItem("flamingo_sound_volume", clampedVolume);
             localStorage.setItem("flamingo_sound_muted", window.__soundMuted);
-            if (window.__soundMuted) {
-              window.dispatchEvent(new Event("flamingo:mute"));
+            muteButton.setAttribute("aria-pressed", window.__soundMuted);
+
+            if (clampedVolume > 0) {
+              localStorage.setItem("flamingo_sound_previous_volume", clampedVolume);
             }
+
+            for (const icon of icons) {
+              icon.classList.toggle("hidden", icon.dataset.soundVolumeIcon !== visibleIcon);
+            }
+
+            window.dispatchEvent(new CustomEvent("flamingo:volumechange", {
+              detail: { volume: clampedVolume }
+            }));
+          };
+
+          applyVolume(storedVolume());
+          slider.addEventListener("input", () => applyVolume(slider.value));
+          muteButton.addEventListener("click", () => {
+            applyVolume(window.__soundVolume === 0 ? storedPreviousVolume() : 0);
           });
         }
       }

--- a/test/flamingo_web/live/home_live_test.exs
+++ b/test/flamingo_web/live/home_live_test.exs
@@ -1,6 +1,7 @@
 defmodule FlamingoWeb.HomeLiveTest do
   use FlamingoWeb.ConnCase, async: true
 
+  import Phoenix.Component
   import Phoenix.LiveViewTest
 
   alias Flamingo.GameSupervisor
@@ -44,5 +45,32 @@ defmodule FlamingoWeb.HomeLiveTest do
     assert html =~ ~s(id="join-button")
     assert html =~ ~s(id="create-room-button")
     assert html =~ ~s(type="submit")
+  end
+
+  test "app layout sound control is a volume slider initialized to full volume" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <FlamingoWeb.Layouts.app flash={%{}}>
+        <div id="layout-child"></div>
+      </FlamingoWeb.Layouts.app>
+      """)
+
+    document = LazyHTML.from_fragment(html)
+
+    assert document |> LazyHTML.query("#sound-volume-control") |> Enum.any?()
+
+    assert document
+           |> LazyHTML.query(
+             "#sound-volume-slider[type='range'][min='0'][max='100'][step='1'][value='100']"
+           )
+           |> Enum.any?()
+
+    assert document
+           |> LazyHTML.query("#sound-volume-icon [data-sound-volume-icon]")
+           |> Enum.count() >= 2
+
+    refute document |> LazyHTML.query("#sound-toggle-switch") |> Enum.any?()
   end
 end

--- a/test/flamingo_web/live/home_live_test.exs
+++ b/test/flamingo_web/live/home_live_test.exs
@@ -59,17 +59,31 @@ defmodule FlamingoWeb.HomeLiveTest do
 
     document = LazyHTML.from_fragment(html)
 
-    assert document |> LazyHTML.query("#sound-volume-control") |> Enum.any?()
+    control = document |> LazyHTML.query("#sound-volume-control")
+    assert control |> Enum.any?()
+
+    [control_class] = LazyHTML.attribute(control, "class")
+    assert control_class =~ "bg-white"
+    assert control_class =~ "border"
+    assert control_class =~ "shadow"
 
     assert document
            |> LazyHTML.query(
-             "#sound-volume-slider[type='range'][min='0'][max='100'][step='1'][value='100']"
+             "#sound-volume-button[type='button'][aria-label='Toggle sound mute']"
+           )
+           |> Enum.any?()
+
+    assert document
+           |> LazyHTML.query(
+             "#sound-volume-slider.nb-slider[type='range'][min='0'][max='100'][step='1'][value='100']"
            )
            |> Enum.any?()
 
     assert document
            |> LazyHTML.query("#sound-volume-icon [data-sound-volume-icon]")
            |> Enum.count() >= 2
+
+    refute LazyHTML.text(control) =~ ":"
 
     refute document |> LazyHTML.query("#sound-toggle-switch") |> Enum.any?()
   end


### PR DESCRIPTION
## Summary
Replace the binary sound toggle with a persistent 0-100 volume slider so players can tune game audio instead of only muting it. The control uses existing volume-level icons and keeps 100 as the current effective volume.

The audio manager now treats the slider as a master volume multiplier while preserving the existing relative levels for music, countdowns, and effects. It also resyncs active round audio when moving from 0 back above 0 so muted clients do not stay silent until the next phase transition.

## Notes
The branch also exposes the existing first-hint delay helper because the current test suite already asserts that delay policy directly.