### PR TITLE
Improve hint scheduling, disconnection handling, and drawing compression

### DIFF
--- a/assets/js/hooks/drawing_canvas.ts
+++ b/assets/js/hooks/drawing_canvas.ts
@@ -9,6 +9,38 @@ export type DrawEvent =
   | { event_type: "undo" }
   | { event_type: "redo" };
 
+// Compact representation used for share links and final-drawing payloads:
+// pen stroke polyline, flood fill, or canvas clear.
+export type CompactOp =
+  | ["p", string, number, number[]]
+  | ["f", string, number, number]
+  | ["c"];
+
+export const opsToEvents = (ops: CompactOp[]) => {
+  const events: DrawEvent[] = [];
+
+  for (const op of ops) {
+    if (op[0] === "p") {
+      const [, color, lineWidth, points] = op;
+      events.push({ event_type: "start", x: points[0], y: points[1], color, line_width: lineWidth });
+      for (let i = 3; i < points.length; i += 2) {
+        events.push({
+          event_type: "draw",
+          start_x: points[i - 3], start_y: points[i - 2],
+          end_x: points[i - 1], end_y: points[i],
+          color, line_width: lineWidth,
+        });
+      }
+    } else if (op[0] === "f") {
+      events.push({ event_type: "fill", x: op[2], y: op[3], color: op[1] });
+    } else if (op[0] === "c") {
+      events.push({ event_type: "clear" });
+    }
+  }
+
+  return events;
+};
+
 interface Point {
   x: number;
   y: number;
@@ -139,8 +171,8 @@ const DrawingCanvas = {
     canvasEffect(this.ctx, (imageData: ImageData) => clear(imageData));
 
     if (this.el.dataset.finalDrawingEvents) {
-      const events = JSON.parse(this.el.dataset.finalDrawingEvents) as DrawEvent[];
-      this.eventStack = [...events];
+      const ops = JSON.parse(this.el.dataset.finalDrawingEvents) as CompactOp[];
+      this.eventStack = opsToEvents(ops);
       this.replayFinalDrawing();
     }
 

--- a/assets/js/hooks/drawing_canvas.ts
+++ b/assets/js/hooks/drawing_canvas.ts
@@ -10,7 +10,8 @@ export type DrawEvent =
   | { event_type: "redo" };
 
 // Compact representation used for share links and final-drawing payloads:
-// pen stroke polyline, flood fill, or canvas clear.
+// pen stroke polyline (delta-encoded after the first point), flood fill, or
+// canvas clear.
 export type CompactOp =
   | ["p", string, number, number[]]
   | ["f", string, number, number]
@@ -21,15 +22,21 @@ export const opsToEvents = (ops: CompactOp[]) => {
 
   for (const op of ops) {
     if (op[0] === "p") {
-      const [, color, lineWidth, points] = op;
-      events.push({ event_type: "start", x: points[0], y: points[1], color, line_width: lineWidth });
-      for (let i = 3; i < points.length; i += 2) {
+      const [, color, lineWidth, nums] = op;
+      let x = nums[0];
+      let y = nums[1];
+      events.push({ event_type: "start", x, y, color, line_width: lineWidth });
+      for (let i = 2; i + 1 < nums.length; i += 2) {
+        const nextX = x + nums[i];
+        const nextY = y + nums[i + 1];
         events.push({
           event_type: "draw",
-          start_x: points[i - 3], start_y: points[i - 2],
-          end_x: points[i - 1], end_y: points[i],
+          start_x: x, start_y: y,
+          end_x: nextX, end_y: nextY,
           color, line_width: lineWidth,
         });
+        x = nextX;
+        y = nextY;
       }
     } else if (op[0] === "f") {
       events.push({ event_type: "fill", x: op[2], y: op[3], color: op[1] });

--- a/assets/js/hooks/shared_drawing.ts
+++ b/assets/js/hooks/shared_drawing.ts
@@ -1,4 +1,4 @@
-import { DrawEvent, replayEvents } from "./drawing_canvas";
+import { CompactOp, DrawEvent, opsToEvents, replayEvents } from "./drawing_canvas";
 
 type SharedDrawingPayload = {
   drawer_name: string;
@@ -7,13 +7,21 @@ type SharedDrawingPayload = {
   events: DrawEvent[];
 };
 
+type CompactPayload = {
+  v: number;
+  n: string;
+  w: string;
+  r: number;
+  o: CompactOp[];
+};
+
 interface SharedDrawingHook {
   el: HTMLElement;
   canvas: HTMLCanvasElement;
   ctx: CanvasRenderingContext2D;
   events: DrawEvent[];
   replayToken: number;
-  loadDrawing: () => void;
+  loadDrawing: () => Promise<void>;
   replay: () => void;
   showInvalid: () => void;
   showDrawing: (drawing: SharedDrawingPayload) => void;
@@ -32,6 +40,28 @@ const decodeBase64UrlJson = (encoded: string) =>
     new TextDecoder().decode(decodeBase64Url(encoded))
   );
 
+const inflate = async (bytes: Uint8Array) => {
+  const stream = new Blob([bytes])
+    .stream()
+    .pipeThrough(new DecompressionStream("deflate"));
+
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+};
+
+// Compressed links are prefixed with "z"; anything else is a legacy link
+// carrying the raw event list as plain base64url JSON.
+const decodeCompressed = async (encoded: string): Promise<SharedDrawingPayload> => {
+  const json = new TextDecoder().decode(await inflate(decodeBase64Url(encoded)));
+  const payload = JSON.parse<CompactPayload>(json);
+
+  return {
+    drawer_name: payload.n,
+    word: payload.w,
+    round_number: payload.r,
+    events: opsToEvents(payload.o),
+  };
+};
+
 const SharedDrawing = {
   mounted(this: SharedDrawingHook) {
     this.canvas = this.el.querySelector("canvas") as HTMLCanvasElement;
@@ -46,16 +76,21 @@ const SharedDrawing = {
     this.loadDrawing();
   },
 
-  loadDrawing(this: SharedDrawingHook) {
+  async loadDrawing(this: SharedDrawingHook) {
     const encoded = window.location.hash.slice(1);
 
-    if (encoded) {
-      try {
-        this.showDrawing(decodeBase64UrlJson(encoded));
-      } catch {
-        this.showInvalid();
-      }
-    } else {
+    if (!encoded) {
+      this.showInvalid();
+      return;
+    }
+
+    try {
+      const drawing = encoded.startsWith("z")
+        ? await decodeCompressed(encoded.slice(1))
+        : decodeBase64UrlJson(encoded);
+
+      this.showDrawing(drawing);
+    } catch {
       this.showInvalid();
     }
   },

--- a/lib/flamingo/drawing_share.ex
+++ b/lib/flamingo/drawing_share.ex
@@ -1,5 +1,13 @@
 defmodule Flamingo.DrawingShare do
-  @moduledoc false
+  @moduledoc """
+  Encodes a finished drawing into a URL fragment.
+
+  Raw draw events are far too heavy to put in a link (hundreds of KB), so we
+  compact them first: pen strokes collapse into simplified integer polylines,
+  fills and clears stay as single ops. The compact payload is then
+  JSON-encoded, zlib-compressed and base64url'd, prefixed with "z" so clients
+  can tell it apart from legacy uncompressed links.
+  """
 
   @type drawing :: %{
           required(:drawer_name) => String.t(),
@@ -8,17 +16,45 @@ defmodule Flamingo.DrawingShare do
           required(:events) => list(map())
         }
 
+  @version_prefix "z"
+  # Minimum distance in px between kept polyline points; small deviations are
+  # invisible at pen widths >= 6.
+  @min_point_gap 2.0
+
   def encode(drawing) do
-    drawing
-    |> payload()
-    |> Jason.encode!()
-    |> Base.url_encode64(padding: false)
+    payload = %{
+      "v" => 2,
+      "n" => Map.fetch!(drawing, :drawer_name),
+      "w" => Map.fetch!(drawing, :word),
+      "r" => Map.fetch!(drawing, :round_number),
+      "o" => compact_ops(Map.fetch!(drawing, :events))
+    }
+
+    compressed =
+      payload
+      |> Jason.encode!()
+      |> :zlib.compress()
+      |> Base.url_encode64(padding: false)
+
+    @version_prefix <> compressed
   end
 
+  def decode(@version_prefix <> encoded) do
+    with {:ok, compressed} <- Base.url_decode64(encoded, padding: false),
+         {:ok, json} <- safe_uncompress(compressed),
+         {:ok, payload} <- Jason.decode(json),
+         {:ok, drawing} <- normalize_v2(payload) do
+      {:ok, drawing}
+    else
+      _ -> {:error, :invalid_drawing}
+    end
+  end
+
+  # Legacy links: plain base64url JSON with the full event list.
   def decode(encoded) when is_binary(encoded) do
     with {:ok, json} <- Base.url_decode64(encoded, padding: false),
          {:ok, payload} <- Jason.decode(json),
-         {:ok, drawing} <- normalize(payload) do
+         {:ok, drawing} <- normalize_v1(payload) do
       {:ok, drawing}
     else
       _ -> {:error, :invalid_drawing}
@@ -27,16 +63,175 @@ defmodule Flamingo.DrawingShare do
 
   def decode(_encoded), do: {:error, :invalid_drawing}
 
-  defp payload(drawing) do
-    %{
-      "drawer_name" => Map.fetch!(drawing, :drawer_name),
-      "word" => Map.fetch!(drawing, :word),
-      "round_number" => Map.fetch!(drawing, :round_number),
-      "events" => Map.fetch!(drawing, :events)
-    }
+  @doc """
+  Collapses raw draw events into compact ops:
+
+    * `["p", color, line_width, [x0, y0, x1, y1, ...]]` - a pen stroke polyline
+    * `["f", color, x, y]` - a flood fill
+    * `["c"]` - a canvas clear
+  """
+  def compact_ops(events) do
+    {ops, stroke} = Enum.reduce(events, {[], nil}, &compact_event/2)
+
+    [flush_stroke(stroke) | ops]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.reverse()
   end
 
-  defp normalize(%{
+  @doc """
+  Expands compact ops back into renderable draw events.
+  """
+  def expand_ops(ops) do
+    Enum.flat_map(ops, &expand_op/1)
+  end
+
+  defp compact_event(%{"event_type" => "start"} = event, {ops, stroke}) do
+    new_stroke = %{
+      color: event["color"],
+      width: event["line_width"],
+      points: [{round_coord(event["x"]), round_coord(event["y"])}]
+    }
+
+    {[flush_stroke(stroke) | ops], new_stroke}
+  end
+
+  defp compact_event(%{"event_type" => type} = event, {ops, stroke})
+       when type in ["draw", "end"] do
+    point = {round_coord(event["end_x"]), round_coord(event["end_y"])}
+
+    case stroke do
+      nil ->
+        start = {round_coord(event["start_x"]), round_coord(event["start_y"])}
+
+        {ops,
+         %{color: event["color"], width: event["line_width"], points: [point, start]}}
+
+      stroke ->
+        {ops, %{stroke | points: [point | stroke.points]}}
+    end
+  end
+
+  defp compact_event(%{"event_type" => "fill"} = event, {ops, stroke}) do
+    op = ["f", event["color"], round_coord(event["x"]), round_coord(event["y"])]
+    {[op, flush_stroke(stroke) | ops], nil}
+  end
+
+  defp compact_event(%{"event_type" => "clear"}, {ops, stroke}) do
+    {[["c"], flush_stroke(stroke) | ops], nil}
+  end
+
+  defp compact_event(_event, acc), do: acc
+
+  defp flush_stroke(nil), do: nil
+
+  defp flush_stroke(stroke) do
+    points =
+      stroke.points
+      |> Enum.reverse()
+      |> simplify_points()
+      |> Enum.flat_map(fn {x, y} -> [x, y] end)
+
+    ["p", stroke.color, stroke.width, points]
+  end
+
+  # Keeps the first point, then only points at least @min_point_gap away from
+  # the previously kept one, and always the final point.
+  defp simplify_points([first | rest]) do
+    {kept, last_kept, last_point} =
+      Enum.reduce(rest, {[first], first, first}, fn point, {kept, last_kept, _last} ->
+        if distance(point, last_kept) >= @min_point_gap do
+          {[point | kept], point, point}
+        else
+          {kept, last_kept, point}
+        end
+      end)
+
+    kept = if last_point != last_kept, do: [last_point | kept], else: kept
+    Enum.reverse(kept)
+  end
+
+  defp simplify_points([]), do: []
+
+  defp distance({x1, y1}, {x2, y2}) do
+    :math.sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2))
+  end
+
+  defp round_coord(value) when is_number(value), do: round(value)
+  defp round_coord(_value), do: 0
+
+  defp expand_op(["p", color, width, [x0, y0 | rest]]) do
+    start = %{
+      "event_type" => "start",
+      "x" => x0,
+      "y" => y0,
+      "color" => color,
+      "line_width" => width
+    }
+
+    {segments, _last} =
+      rest
+      |> Enum.chunk_every(2)
+      |> Enum.map_reduce({x0, y0}, fn [x, y], {prev_x, prev_y} ->
+        segment = %{
+          "event_type" => "draw",
+          "start_x" => prev_x,
+          "start_y" => prev_y,
+          "end_x" => x,
+          "end_y" => y,
+          "color" => color,
+          "line_width" => width
+        }
+
+        {segment, {x, y}}
+      end)
+
+    [start | segments]
+  end
+
+  defp expand_op(["f", color, x, y]) do
+    [%{"event_type" => "fill", "x" => x, "y" => y, "color" => color}]
+  end
+
+  defp expand_op(["c"]) do
+    [%{"event_type" => "clear"}]
+  end
+
+  defp expand_op(_op), do: []
+
+  defp safe_uncompress(compressed) do
+    {:ok, :zlib.uncompress(compressed)}
+  rescue
+    _error -> {:error, :invalid_drawing}
+  end
+
+  defp normalize_v2(%{"v" => 2, "n" => name, "w" => word, "r" => round_number, "o" => ops})
+       when is_binary(name) and is_binary(word) and is_integer(round_number) and
+              round_number > 0 and is_list(ops) do
+    if Enum.all?(ops, &valid_op?/1) do
+      {:ok,
+       %{
+         drawer_name: name,
+         word: word,
+         round_number: round_number,
+         events: expand_ops(ops)
+       }}
+    else
+      {:error, :invalid_drawing}
+    end
+  end
+
+  defp normalize_v2(_payload), do: {:error, :invalid_drawing}
+
+  defp valid_op?(["p", color, width, points]) when is_binary(color) and is_number(width) do
+    is_list(points) and rem(length(points), 2) == 0 and points != [] and
+      Enum.all?(points, &is_number/1)
+  end
+
+  defp valid_op?(["f", color, x, y]), do: is_binary(color) and is_number(x) and is_number(y)
+  defp valid_op?(["c"]), do: true
+  defp valid_op?(_op), do: false
+
+  defp normalize_v1(%{
          "drawer_name" => drawer_name,
          "word" => word,
          "round_number" => round_number,
@@ -51,5 +246,5 @@ defmodule Flamingo.DrawingShare do
     end
   end
 
-  defp normalize(_payload), do: {:error, :invalid_drawing}
+  defp normalize_v1(_payload), do: {:error, :invalid_drawing}
 end

--- a/lib/flamingo/drawing_share.ex
+++ b/lib/flamingo/drawing_share.ex
@@ -2,24 +2,37 @@ defmodule Flamingo.DrawingShare do
   @moduledoc """
   Encodes a finished drawing into a URL fragment.
 
-  Raw draw events are far too heavy to put in a link (hundreds of KB), so we
-  compact them first: pen strokes collapse into simplified integer polylines,
-  fills and clears stay as single ops. The compact payload is then
-  JSON-encoded, zlib-compressed and base64url'd, prefixed with "z" so clients
-  can tell it apart from legacy uncompressed links.
+  Raw draw events are far too heavy to put in a link (hundreds of KB), so
+  drawings are reduced to compact ops the moment a turn completes:
+
+    * pen strokes become polylines simplified with Ramer-Douglas-Peucker
+      under a total point budget - the tolerance escalates until the whole
+      drawing fits, so busy sketches trade fidelity for size instead of
+      producing huge payloads;
+    * polyline coordinates are delta-encoded integers, which keeps the
+      numbers small and compresses well;
+    * fills and clears are single ops.
+
+  The payload is JSON-encoded, zlib-compressed and base64url'd, prefixed
+  with "z" so clients can tell it apart from legacy uncompressed links.
+  A typical drawing encodes to roughly 1KB.
   """
 
   @type drawing :: %{
           required(:drawer_name) => String.t(),
           required(:word) => String.t(),
           required(:round_number) => pos_integer(),
-          required(:events) => list(map())
+          required(:ops) => list(list())
         }
 
   @version_prefix "z"
-  # Minimum distance in px between kept polyline points; small deviations are
-  # invisible at pen widths >= 6.
-  @min_point_gap 2.0
+
+  # Total polyline points allowed across the whole drawing. RDP tolerance
+  # steps up through @epsilon_steps until the drawing fits (or the roughest
+  # tolerance is reached - e.g. hundreds of separate dots can't be reduced
+  # below two points per stroke, so the budget is best-effort).
+  @max_total_points 200
+  @epsilon_steps [1.5, 3, 6, 12, 24, 48, 96]
 
   def encode(drawing) do
     payload = %{
@@ -27,7 +40,7 @@ defmodule Flamingo.DrawingShare do
       "n" => Map.fetch!(drawing, :drawer_name),
       "w" => Map.fetch!(drawing, :word),
       "r" => Map.fetch!(drawing, :round_number),
-      "o" => compact_ops(Map.fetch!(drawing, :events))
+      "o" => Map.fetch!(drawing, :ops)
     }
 
     compressed =
@@ -66,16 +79,26 @@ defmodule Flamingo.DrawingShare do
   @doc """
   Collapses raw draw events into compact ops:
 
-    * `["p", color, line_width, [x0, y0, x1, y1, ...]]` - a pen stroke polyline
+    * `["p", color, line_width, [x0, y0, dx1, dy1, ...]]` - a simplified,
+      delta-encoded pen stroke polyline
     * `["f", color, x, y]` - a flood fill
     * `["c"]` - a canvas clear
   """
   def compact_ops(events) do
-    {ops, stroke} = Enum.reduce(events, {[], nil}, &compact_event/2)
+    raw_ops = collect_ops(events)
 
-    [flush_stroke(stroke) | ops]
-    |> Enum.reject(&is_nil/1)
-    |> Enum.reverse()
+    epsilon = choose_epsilon(raw_ops)
+
+    Enum.map(raw_ops, fn
+      {:stroke, color, width, points} ->
+        ["p", color, width, points |> simplify(epsilon) |> delta_encode()]
+
+      {:fill, color, x, y} ->
+        ["f", color, x, y]
+
+      :clear ->
+        ["c"]
+    end)
   end
 
   @doc """
@@ -85,81 +108,123 @@ defmodule Flamingo.DrawingShare do
     Enum.flat_map(ops, &expand_op/1)
   end
 
-  defp compact_event(%{"event_type" => "start"} = event, {ops, stroke}) do
-    new_stroke = %{
-      color: event["color"],
-      width: event["line_width"],
-      points: [{round_coord(event["x"]), round_coord(event["y"])}]
-    }
+  defp collect_ops(events) do
+    {ops, stroke} = Enum.reduce(events, {[], nil}, &collect_event/2)
 
-    {[flush_stroke(stroke) | ops], new_stroke}
+    [flush_stroke(stroke) | ops]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.reverse()
   end
 
-  defp compact_event(%{"event_type" => type} = event, {ops, stroke})
+  defp collect_event(%{"event_type" => "start"} = event, {ops, stroke}) do
+    point = {round_coord(event["x"]), round_coord(event["y"])}
+    {[flush_stroke(stroke) | ops], {event["color"], event["line_width"], [point]}}
+  end
+
+  defp collect_event(%{"event_type" => type} = event, {ops, stroke})
        when type in ["draw", "end"] do
     point = {round_coord(event["end_x"]), round_coord(event["end_y"])}
 
     case stroke do
       nil ->
         start = {round_coord(event["start_x"]), round_coord(event["start_y"])}
+        {ops, {event["color"], event["line_width"], [point, start]}}
 
-        {ops,
-         %{color: event["color"], width: event["line_width"], points: [point, start]}}
+      {color, width, [^point | _] = points} ->
+        {ops, {color, width, points}}
 
-      stroke ->
-        {ops, %{stroke | points: [point | stroke.points]}}
+      {color, width, points} ->
+        {ops, {color, width, [point | points]}}
     end
   end
 
-  defp compact_event(%{"event_type" => "fill"} = event, {ops, stroke}) do
-    op = ["f", event["color"], round_coord(event["x"]), round_coord(event["y"])]
+  defp collect_event(%{"event_type" => "fill"} = event, {ops, stroke}) do
+    op = {:fill, event["color"], round_coord(event["x"]), round_coord(event["y"])}
     {[op, flush_stroke(stroke) | ops], nil}
   end
 
-  defp compact_event(%{"event_type" => "clear"}, {ops, stroke}) do
-    {[["c"], flush_stroke(stroke) | ops], nil}
+  defp collect_event(%{"event_type" => "clear"}, {ops, stroke}) do
+    {[:clear, flush_stroke(stroke) | ops], nil}
   end
 
-  defp compact_event(_event, acc), do: acc
+  defp collect_event(_event, acc), do: acc
 
   defp flush_stroke(nil), do: nil
 
-  defp flush_stroke(stroke) do
-    points =
-      stroke.points
-      |> Enum.reverse()
-      |> simplify_points()
-      |> Enum.flat_map(fn {x, y} -> [x, y] end)
-
-    ["p", stroke.color, stroke.width, points]
+  defp flush_stroke({color, width, points}) do
+    {:stroke, color, width, Enum.reverse(points)}
   end
 
-  # Keeps the first point, then only points at least @min_point_gap away from
-  # the previously kept one, and always the final point.
-  defp simplify_points([first | rest]) do
-    {kept, last_kept, last_point} =
-      Enum.reduce(rest, {[first], first, first}, fn point, {kept, last_kept, _last} ->
-        if distance(point, last_kept) >= @min_point_gap do
-          {[point | kept], point, point}
-        else
-          {kept, last_kept, point}
-        end
+  defp choose_epsilon(raw_ops) do
+    point_lists = for {:stroke, _color, _width, points} <- raw_ops, do: points
+
+    Enum.find(@epsilon_steps, List.last(@epsilon_steps), fn epsilon ->
+      total =
+        point_lists
+        |> Enum.map(&length(simplify(&1, epsilon)))
+        |> Enum.sum()
+
+      total <= @max_total_points
+    end)
+  end
+
+  # Ramer-Douglas-Peucker: keeps the points that define the stroke's shape
+  # (corners, curves) and drops everything within `epsilon` px of the
+  # simplified line.
+  defp simplify(points, _epsilon) when length(points) <= 2, do: points
+
+  defp simplify(points, epsilon) do
+    first = List.first(points)
+    last = List.last(points)
+
+    {max_distance, max_index} =
+      points
+      |> Enum.with_index()
+      |> Enum.reduce({0.0, 0}, fn {point, index}, {best_distance, best_index} ->
+        distance = perpendicular_distance(point, first, last)
+
+        if distance > best_distance,
+          do: {distance, index},
+          else: {best_distance, best_index}
       end)
 
-    kept = if last_point != last_kept, do: [last_point | kept], else: kept
-    Enum.reverse(kept)
+    if max_distance > epsilon do
+      {left, right} = Enum.split(points, max_index + 1)
+      simplify(left, epsilon) ++ tl(simplify([Enum.at(points, max_index) | right], epsilon))
+    else
+      [first, last]
+    end
   end
 
-  defp simplify_points([]), do: []
+  defp perpendicular_distance({px, py}, {x1, y1} = first, {x2, y2} = last) do
+    if first == last do
+      distance({px, py}, first)
+    else
+      dx = x2 - x1
+      dy = y2 - y1
+      abs(dy * px - dx * py + x2 * y1 - y2 * x1) / :math.sqrt(dx * dx + dy * dy)
+    end
+  end
 
   defp distance({x1, y1}, {x2, y2}) do
     :math.sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2))
   end
 
+  defp delta_encode([{x0, y0} | rest]) do
+    {deltas, _last} =
+      Enum.map_reduce(rest, {x0, y0}, fn {x, y}, {prev_x, prev_y} ->
+        {[x - prev_x, y - prev_y], {x, y}}
+      end)
+
+    [x0, y0 | List.flatten(deltas)]
+  end
+
+  defp delta_encode([]), do: []
+
   defp round_coord(value) when is_number(value), do: round(value)
   defp round_coord(_value), do: 0
 
-  defp expand_op(["p", color, width, [x0, y0 | rest]]) do
+  defp expand_op(["p", color, width, [x0, y0 | deltas]]) do
     start = %{
       "event_type" => "start",
       "x" => x0,
@@ -169,9 +234,12 @@ defmodule Flamingo.DrawingShare do
     }
 
     {segments, _last} =
-      rest
+      deltas
       |> Enum.chunk_every(2)
-      |> Enum.map_reduce({x0, y0}, fn [x, y], {prev_x, prev_y} ->
+      |> Enum.map_reduce({x0, y0}, fn [dx, dy], {prev_x, prev_y} ->
+        x = prev_x + dx
+        y = prev_y + dy
+
         segment = %{
           "event_type" => "draw",
           "start_x" => prev_x,

--- a/lib/flamingo/feed.ex
+++ b/lib/flamingo/feed.ex
@@ -1,59 +1,52 @@
 defmodule Flamingo.Feed do
-  defstruct events: []
+  defstruct events: [], next_id: 1
 
   def new(), do: %__MODULE__{}
 
-  def player_joined(feed, player_id, name) do
-    event = {:player_joined, player_id, name}
-    {%{feed | events: feed.events ++ [event]}, event}
+  def player_joined(feed, player_id, name), do: add(feed, {:player_joined, player_id, name})
+
+  def player_left(feed, player_id, name), do: add(feed, {:player_left, player_id, name})
+
+  def new_turn(feed, player_id, name), do: add(feed, {:new_turn, player_id, name})
+
+  def guess(feed, player_id, name, text), do: add(feed, {:guess, player_id, name, text})
+
+  def close_guess(feed, player_id), do: add(feed, {:close_guess, player_id})
+
+  def correct_guess(feed, player_id, name), do: add(feed, {:correct_guess, player_id, name})
+
+  def word_revealed(feed, word), do: add(feed, {:word_revealed, word})
+
+  defp add(feed, event) do
+    entry = %{id: feed.next_id, event: event}
+    {%{feed | events: feed.events ++ [entry], next_id: feed.next_id + 1}, entry}
   end
 
-  def player_left(feed, player_id, name) do
-    event = {:player_left, player_id, name}
-    {%{feed | events: feed.events ++ [event]}, event}
+  def format(%{id: id, event: event}, viewer) do
+    case format_event(event, viewer) do
+      nil -> nil
+      {kind, text} -> %{id: id, kind: kind, text: text}
+    end
   end
 
-  def new_turn(feed, player_id, name) do
-    event = {:new_turn, player_id, name}
-    {%{feed | events: feed.events ++ [event]}, event}
-  end
+  defp format_event({:player_joined, _player_id, name}, _viewer), do: {:info, "#{name} joined"}
+  defp format_event({:player_left, _player_id, name}, _viewer), do: {:info, "#{name} left"}
 
-  def guess(feed, player_id, name, text) do
-    event = {:guess, player_id, name, text}
-    {%{feed | events: feed.events ++ [event]}, event}
-  end
+  defp format_event({:new_turn, _player_id, name}, _viewer),
+    do: {:system, "It's #{name}'s turn to draw"}
 
-  def close_guess(feed, player_id) do
-    event = {:close_guess, player_id}
-    {%{feed | events: feed.events ++ [event]}, event}
-  end
+  defp format_event({:guess, _player_id, name, text}, _viewer), do: {:guess, "#{name}: #{text}"}
 
-  def correct_guess(feed, player_id, name) do
-    event = {:correct_guess, player_id, name}
-    {%{feed | events: feed.events ++ [event]}, event}
-  end
-
-  def word_revealed(feed, word) do
-    event = {:word_revealed, word}
-    {%{feed | events: feed.events ++ [event]}, event}
-  end
-
-  def format({:player_joined, _player_id, name}, _viewer), do: {:info, "#{name} joined"}
-  def format({:player_left, _player_id, name}, _viewer), do: {:info, "#{name} left"}
-
-  def format({:new_turn, _player_id, name}, _viewer), do: {:system, "It's #{name}'s turn to draw"}
-  def format({:guess, _player_id, name, text}, _viewer), do: {:guess, "#{name}: #{text}"}
-
-  def format({:close_guess, player_id}, viewer) when player_id == viewer,
+  defp format_event({:close_guess, player_id}, viewer) when player_id == viewer,
     do: {:close, "You were close"}
 
-  def format({:close_guess, _player_id}, _viewer), do: nil
+  defp format_event({:close_guess, _player_id}, _viewer), do: nil
 
-  def format({:correct_guess, player_id, _name}, viewer) when player_id == viewer,
+  defp format_event({:correct_guess, player_id, _name}, viewer) when player_id == viewer,
     do: {:correct, "You guessed it"}
 
-  def format({:correct_guess, _player_id, name}, _viewer),
+  defp format_event({:correct_guess, _player_id, name}, _viewer),
     do: {:correct, "#{name} guessed the word"}
 
-  def format({:word_revealed, word}, _viewer), do: {:system, "The word was #{word}"}
+  defp format_event({:word_revealed, word}, _viewer), do: {:system, "The word was #{word}"}
 end

--- a/lib/flamingo/game_server.ex
+++ b/lib/flamingo/game_server.ex
@@ -589,12 +589,14 @@ defmodule Flamingo.GameServer do
     new_state
   end
 
+  # Raw draw events are dropped here: the compact ops are all the game-end
+  # screen and share links need, and they're orders of magnitude smaller.
   defp completed_drawing(state) do
     %{
       drawer_id: state.drawer_id,
       word: state.word,
       round_number: state.current_round + 1,
-      events: state.current_drawing
+      ops: Flamingo.DrawingShare.compact_ops(state.current_drawing)
     }
   end
 

--- a/lib/flamingo/game_server.ex
+++ b/lib/flamingo/game_server.ex
@@ -5,8 +5,16 @@ defmodule Flamingo.GameServer do
 
   @min_turn_length 15
   @max_turn_length 120
-  @hint_interval_ms 20_000
-  @hint_before_turn_end_ms 5_000
+
+  # Letter hints are revealed evenly across this window of the turn, so every
+  # round length gets a full spread of hints rather than a fixed interval that
+  # only fits long rounds.
+  @hint_window_start 0.35
+  @hint_window_end 0.9
+
+  # How long a disconnected player keeps their seat (and score) before being
+  # removed. Covers flaky connections and page reloads mid-game.
+  @disconnect_grace_ms 60_000
 
   defstruct [
     :room_id,
@@ -28,6 +36,8 @@ defmodule Flamingo.GameServer do
     correct_guesses: %{},
     revealed_indices: [],
     hint_timer_ref: nil,
+    pending_hint_delays: [],
+    disconnect_timers: %{},
     score_gains: %{},
     final_drawings: [],
     feed: Feed.new()
@@ -77,8 +87,19 @@ defmodule Flamingo.GameServer do
     :exit, {:noproc, _} -> {:error, :not_found}
   end
 
-  def first_hint_delay_ms(turn_length) do
-    min(@hint_interval_ms, max(1_000, turn_length * 1000 - @hint_before_turn_end_ms))
+  @doc """
+  Millisecond offsets from turn start at which letters are revealed, spread
+  evenly across the middle of the turn. Up to half the word's letters are
+  revealed, so shorter rounds and longer words both get useful hints.
+  """
+  def hint_schedule(word, turn_length) do
+    max_reveals = word |> letter_positions() |> length() |> div(2)
+    turn_ms = turn_length * 1000
+    window = @hint_window_end - @hint_window_start
+
+    for k <- 1..max_reveals//1 do
+      trunc(turn_ms * (@hint_window_start + window * (k - 0.5) / max_reveals))
+    end
   end
 
   defp via(room_id) do
@@ -93,7 +114,7 @@ defmodule Flamingo.GameServer do
   @impl true
   def handle_call({:join, player_name}, _from, state) do
     player_id = generate_player_id()
-    player = %{id: player_id, name: player_name, score: 0}
+    player = %{id: player_id, name: player_name, score: 0, connected: true}
 
     players = Map.put(state.players, player_id, player)
     player_order = state.player_order ++ [player_id]
@@ -101,22 +122,19 @@ defmodule Flamingo.GameServer do
 
     new_state = %{state | players: players, player_order: player_order, host_id: host_id}
 
-    {feed, event} = Feed.player_joined(new_state.feed, player_id, player_name)
+    {feed, entry} = Feed.player_joined(new_state.feed, player_id, player_name)
     new_state = %{new_state | feed: feed}
 
-    broadcast(
-      state.room_id,
-      {:players_updated, new_state.players, new_state.player_order, new_state.host_id}
-    )
-
-    broadcast(state.room_id, {:feed_event, event})
+    broadcast_players_updated(new_state)
+    broadcast(state.room_id, {:feed_event, entry})
 
     {:reply, {:ok, player_id, new_state}, new_state}
   end
 
   def handle_call({:rejoin, player_id}, _from, state) do
     if Map.has_key?(state.players, player_id) do
-      {:reply, {:ok, state}, state}
+      new_state = mark_connected(state, player_id)
+      {:reply, {:ok, new_state}, new_state}
     else
       {:reply, {:error, :not_found}, state}
     end
@@ -189,32 +207,28 @@ defmodule Flamingo.GameServer do
       String.downcase(String.trim(text)) == String.downcase(state.word) ->
         player = Map.get(state.players, player_id)
         correct_guesses = Map.put(state.correct_guesses, player_id, DateTime.utc_now())
-        {feed, event} = Feed.correct_guess(state.feed, player_id, player.name)
+        {feed, entry} = Feed.correct_guess(state.feed, player_id, player.name)
         new_state = %{state | correct_guesses: correct_guesses, feed: feed}
         broadcast(state.room_id, {:correct_guess, player_id})
-        broadcast(state.room_id, {:feed_event, event})
+        broadcast(state.room_id, {:feed_event, entry})
 
-        non_drawers =
-          Enum.reject(state.player_order, &(&1 == state.drawer_id))
+        new_state =
+          if all_connected_guessed?(new_state), do: enter_turn_reveal(new_state), else: new_state
 
-        all_guessed? =
-          Enum.all?(non_drawers, &Map.has_key?(correct_guesses, &1))
-
-        new_state = if all_guessed?, do: enter_turn_reveal(new_state), else: new_state
         {:reply, :correct, new_state}
 
       close_guess?(text, state.word) ->
-        {feed, event} = Feed.close_guess(state.feed, player_id)
+        {feed, entry} = Feed.close_guess(state.feed, player_id)
         new_state = %{state | feed: feed}
-        broadcast(state.room_id, {:feed_event, event})
+        broadcast(state.room_id, {:feed_event, entry})
         {:reply, :close, new_state}
 
       true ->
         player = Map.get(state.players, player_id)
-        {feed, event} = Feed.guess(state.feed, player_id, player.name, text)
+        {feed, entry} = Feed.guess(state.feed, player_id, player.name, text)
         new_state = %{state | feed: feed}
         broadcast(state.room_id, {:incorrect_guess, player_id, text})
-        broadcast(state.room_id, {:feed_event, event})
+        broadcast(state.room_id, {:feed_event, entry})
         {:reply, :incorrect, new_state}
     end
   end
@@ -224,53 +238,15 @@ defmodule Flamingo.GameServer do
   end
 
   def handle_call({:leave, player_id}, _from, state) do
-    if not Map.has_key?(state.players, player_id) do
-      {:reply, :ok, state}
-    else
-      player_name = Map.get(state.players, player_id).name
-      players = Map.delete(state.players, player_id)
-      player_order = List.delete(state.player_order, player_id)
+    cond do
+      not Map.has_key?(state.players, player_id) ->
+        {:reply, :ok, state}
 
-      host_id =
-        if state.host_id == player_id,
-          do: List.first(player_order),
-          else: state.host_id
+      state.phase in [:lobby, :game_ended] ->
+        {:reply, :ok, remove_player(state, player_id)}
 
-      correct_guesses = Map.delete(state.correct_guesses, player_id)
-
-      new_state = %{
-        state
-        | players: players,
-          player_order: player_order,
-          host_id: host_id,
-          correct_guesses: correct_guesses
-      }
-
-      {feed, event} = Feed.player_left(new_state.feed, player_id, player_name)
-      new_state = %{new_state | feed: feed}
-
-      broadcast(
-        state.room_id,
-        {:players_updated, new_state.players, new_state.player_order, new_state.host_id}
-      )
-
-      broadcast(state.room_id, {:feed_event, event})
-
-      new_state =
-        if state.phase == :playing and player_id != state.drawer_id do
-          non_drawers = Enum.reject(player_order, &(&1 == state.drawer_id))
-
-          if non_drawers != [] and
-               Enum.all?(non_drawers, &Map.has_key?(correct_guesses, &1)) do
-            enter_turn_reveal(new_state)
-          else
-            new_state
-          end
-        else
-          new_state
-        end
-
-      {:reply, :ok, new_state}
+      true ->
+        {:reply, :ok, mark_disconnected(state, player_id)}
     end
   end
 
@@ -304,16 +280,25 @@ defmodule Flamingo.GameServer do
     case maybe_reveal_letter(state) do
       {:ok, new_state} ->
         broadcast(state.room_id, {:hint_revealed, new_state.revealed_indices})
-        next_ref = schedule_hint_timer()
-        {:noreply, %{new_state | hint_timer_ref: next_ref}}
+        {:noreply, schedule_next_hint(new_state)}
 
       :maxed ->
-        {:noreply, %{state | hint_timer_ref: nil}}
+        {:noreply, %{state | hint_timer_ref: nil, pending_hint_delays: []}}
     end
   end
 
   def handle_info({:reveal_hint, _stale_ref}, state) do
     {:noreply, state}
+  end
+
+  def handle_info({:remove_player, player_id, ref}, state) do
+    player = Map.get(state.players, player_id)
+
+    if player && !player.connected && Map.get(state.disconnect_timers, player_id) == ref do
+      {:noreply, remove_player(state, player_id)}
+    else
+      {:noreply, state}
+    end
   end
 
   @impl true
@@ -349,6 +334,100 @@ defmodule Flamingo.GameServer do
     {:noreply, state}
   end
 
+  defp mark_connected(state, player_id) do
+    player = Map.fetch!(state.players, player_id)
+
+    if player.connected do
+      state
+    else
+      players = Map.put(state.players, player_id, %{player | connected: true})
+      disconnect_timers = Map.delete(state.disconnect_timers, player_id)
+      new_state = %{state | players: players, disconnect_timers: disconnect_timers}
+      broadcast_players_updated(new_state)
+      new_state
+    end
+  end
+
+  defp mark_disconnected(state, player_id) do
+    player = Map.fetch!(state.players, player_id)
+    players = Map.put(state.players, player_id, %{player | connected: false})
+
+    ref = make_ref()
+    Process.send_after(self(), {:remove_player, player_id, ref}, @disconnect_grace_ms)
+    disconnect_timers = Map.put(state.disconnect_timers, player_id, ref)
+
+    new_state = %{state | players: players, disconnect_timers: disconnect_timers}
+    broadcast_players_updated(new_state)
+
+    reconcile_turn_completion(new_state, player_id)
+  end
+
+  defp remove_player(state, player_id) do
+    player_name = Map.get(state.players, player_id).name
+    players = Map.delete(state.players, player_id)
+    player_order = List.delete(state.player_order, player_id)
+
+    host_id =
+      if state.host_id == player_id,
+        do: List.first(player_order),
+        else: state.host_id
+
+    correct_guesses = Map.delete(state.correct_guesses, player_id)
+    disconnect_timers = Map.delete(state.disconnect_timers, player_id)
+
+    new_state = %{
+      state
+      | players: players,
+        player_order: player_order,
+        host_id: host_id,
+        correct_guesses: correct_guesses,
+        disconnect_timers: disconnect_timers
+    }
+
+    {feed, entry} = Feed.player_left(new_state.feed, player_id, player_name)
+    new_state = %{new_state | feed: feed}
+
+    broadcast_players_updated(new_state)
+    broadcast(state.room_id, {:feed_event, entry})
+
+    cond do
+      state.phase in [:word_choice, :playing] and player_id == state.drawer_id ->
+        skip_removed_drawer(new_state)
+
+      state.phase == :playing ->
+        reconcile_turn_completion(new_state, player_id)
+
+      true ->
+        new_state
+    end
+  end
+
+  defp skip_removed_drawer(state) do
+    case state.phase do
+      :word_choice -> enter_next_turn(state)
+      :playing -> enter_turn_reveal(state)
+    end
+  end
+
+  defp reconcile_turn_completion(state, player_id) do
+    if state.phase == :playing and player_id != state.drawer_id and
+         all_connected_guessed?(state) do
+      enter_turn_reveal(state)
+    else
+      state
+    end
+  end
+
+  defp all_connected_guessed?(state) do
+    connected_guessers =
+      Enum.filter(state.player_order, fn pid ->
+        pid != state.drawer_id and Map.fetch!(state.players, pid).connected
+      end)
+
+    connected_guessers != [] and
+      Enum.all?(connected_guessers, &Map.has_key?(state.correct_guesses, &1))
+  end
+
   defp enter_word_choice(state) do
     word_choices = Flamingo.Words.random_choices(3, state.used_words)
 
@@ -373,11 +452,12 @@ defmodule Flamingo.GameServer do
         word: nil,
         correct_guesses: %{},
         revealed_indices: [],
-        hint_timer_ref: nil
+        hint_timer_ref: nil,
+        pending_hint_delays: []
     }
 
     drawer_name = Map.get(new_state.players, new_state.drawer_id).name
-    {feed, event} = Feed.new_turn(new_state.feed, new_state.drawer_id, drawer_name)
+    {feed, entry} = Feed.new_turn(new_state.feed, new_state.drawer_id, drawer_name)
     new_state = %{new_state | feed: feed}
 
     broadcast(
@@ -386,7 +466,7 @@ defmodule Flamingo.GameServer do
        new_state.round_count, new_state.turn_length, new_state.current_round}
     )
 
-    broadcast(new_state.room_id, {:feed_event, event})
+    broadcast(new_state.room_id, {:feed_event, entry})
 
     new_state
   end
@@ -395,21 +475,23 @@ defmodule Flamingo.GameServer do
     ref = make_ref()
     Process.send_after(self(), {:playing_timeout, ref}, state.turn_length * 1000)
     turn_end_time = DateTime.add(DateTime.utc_now(), state.turn_length, :second)
-    hint_ref = schedule_hint_timer(first_hint_delay_ms(state.turn_length))
 
-    new_state = %{
-      state
-      | phase: :playing,
-        word: word,
-        used_words: MapSet.put(state.used_words, word),
-        word_choices: [],
-        phase_timer_ref: ref,
-        turn_end_time: turn_end_time,
-        current_drawing: [],
-        correct_guesses: %{},
-        revealed_indices: [],
-        hint_timer_ref: hint_ref
-    }
+    new_state =
+      %{
+        state
+        | phase: :playing,
+          word: word,
+          used_words: MapSet.put(state.used_words, word),
+          word_choices: [],
+          phase_timer_ref: ref,
+          turn_end_time: turn_end_time,
+          current_drawing: [],
+          correct_guesses: %{},
+          revealed_indices: [],
+          hint_timer_ref: nil,
+          pending_hint_delays: hint_delays(word, state.turn_length)
+      }
+      |> schedule_next_hint()
 
     broadcast(state.room_id, {:turn_started, state.drawer_id, word, turn_end_time})
     new_state
@@ -427,6 +509,7 @@ defmodule Flamingo.GameServer do
         state.player_order,
         state.turn_length
       )
+      |> Map.filter(fn {pid, _gain} -> Map.has_key?(state.players, pid) end)
 
     players =
       Map.new(state.players, fn {pid, player} ->
@@ -443,14 +526,15 @@ defmodule Flamingo.GameServer do
         final_drawings: state.final_drawings ++ [completed_drawing(state)],
         score_gains: score_gains,
         players: players,
-        hint_timer_ref: nil
+        hint_timer_ref: nil,
+        pending_hint_delays: []
     }
 
-    {feed, event} = Feed.word_revealed(new_state.feed, state.word)
+    {feed, entry} = Feed.word_revealed(new_state.feed, state.word)
     new_state = %{new_state | feed: feed}
 
     broadcast(state.room_id, {:turn_reveal, state.word, turn_end_time, score_gains, players})
-    broadcast(state.room_id, {:feed_event, event})
+    broadcast(state.room_id, {:feed_event, entry})
     new_state
   end
 
@@ -459,26 +543,35 @@ defmodule Flamingo.GameServer do
 
     next_drawer =
       Enum.find(state.player_order, fn pid ->
-        not MapSet.member?(state.drawn_this_round, pid)
+        not MapSet.member?(state.drawn_this_round, pid) and
+          Map.fetch!(state.players, pid).connected
       end)
 
-    if next_drawer do
-      %{state | drawer_id: next_drawer}
-      |> enter_word_choice()
-    else
-      new_round = state.current_round + 1
-
-      if new_round >= state.round_count do
-        enter_game_ended(state)
-      else
-        %{
-          state
-          | current_round: new_round,
-            drawn_this_round: MapSet.new(),
-            drawer_id: List.first(state.player_order)
-        }
+    cond do
+      next_drawer ->
+        %{state | drawer_id: next_drawer}
         |> enter_word_choice()
-      end
+
+      state.current_round + 1 >= state.round_count ->
+        enter_game_ended(state)
+
+      true ->
+        first_connected =
+          Enum.find(state.player_order, fn pid ->
+            Map.fetch!(state.players, pid).connected
+          end)
+
+        if first_connected do
+          %{
+            state
+            | current_round: state.current_round + 1,
+              drawn_this_round: MapSet.new(),
+              drawer_id: first_connected
+          }
+          |> enter_word_choice()
+        else
+          enter_game_ended(state)
+        end
     end
   end
 
@@ -488,7 +581,8 @@ defmodule Flamingo.GameServer do
       | phase: :game_ended,
         phase_timer_ref: nil,
         turn_end_time: nil,
-        hint_timer_ref: nil
+        hint_timer_ref: nil,
+        pending_hint_delays: []
     }
 
     broadcast(state.room_id, {:game_ended, state.players, state.final_drawings})
@@ -509,7 +603,8 @@ defmodule Flamingo.GameServer do
   end
 
   defp validate_player_count(state) do
-    if map_size(state.players) >= 2, do: :ok, else: {:error, :not_enough_players}
+    connected_count = Enum.count(state.players, fn {_pid, player} -> player.connected end)
+    if connected_count >= 2, do: :ok, else: {:error, :not_enough_players}
   end
 
   defp validate_round_count(count) when count >= 1 and count <= 5, do: :ok
@@ -525,19 +620,35 @@ defmodule Flamingo.GameServer do
     :crypto.strong_rand_bytes(8) |> Base.url_encode64(padding: false)
   end
 
-  defp schedule_hint_timer(delay_ms \\ @hint_interval_ms) do
+  defp hint_delays(word, turn_length) do
+    {deltas, _prev} =
+      word
+      |> hint_schedule(turn_length)
+      |> Enum.map_reduce(0, fn offset, prev -> {offset - prev, offset} end)
+
+    deltas
+  end
+
+  defp schedule_next_hint(%{pending_hint_delays: []} = state) do
+    %{state | hint_timer_ref: nil}
+  end
+
+  defp schedule_next_hint(%{pending_hint_delays: [delay | rest]} = state) do
     ref = make_ref()
-    Process.send_after(self(), {:reveal_hint, ref}, delay_ms)
-    ref
+    Process.send_after(self(), {:reveal_hint, ref}, delay)
+    %{state | hint_timer_ref: ref, pending_hint_delays: rest}
+  end
+
+  defp letter_positions(word) do
+    word
+    |> String.graphemes()
+    |> Enum.with_index()
+    |> Enum.filter(fn {ch, _idx} -> ch =~ ~r/[a-zA-Z]/ end)
+    |> Enum.map(&elem(&1, 1))
   end
 
   defp maybe_reveal_letter(state) do
-    letter_positions =
-      state.word
-      |> String.graphemes()
-      |> Enum.with_index()
-      |> Enum.filter(fn {ch, _idx} -> ch =~ ~r/[a-zA-Z]/ end)
-      |> Enum.map(&elem(&1, 1))
+    letter_positions = letter_positions(state.word)
 
     max_reveals = div(length(letter_positions), 2)
     available = Enum.reject(letter_positions, &(&1 in state.revealed_indices))
@@ -548,6 +659,13 @@ defmodule Flamingo.GameServer do
     else
       :maxed
     end
+  end
+
+  defp broadcast_players_updated(state) do
+    broadcast(
+      state.room_id,
+      {:players_updated, state.players, state.player_order, state.host_id}
+    )
   end
 
   defp broadcast(room_id, message) do

--- a/lib/flamingo/scoring.ex
+++ b/lib/flamingo/scoring.ex
@@ -56,8 +56,7 @@ defmodule Flamingo.Scoring do
     {scores, _prev} =
       sorted
       |> Enum.with_index()
-      |> Enum.reduce({%{}, @first_score}, fn {{player_id, guess_time}, rank},
-                                             {acc, prev_score} ->
+      |> Enum.reduce({%{}, @first_score}, fn {{player_id, guess_time}, rank}, {acc, prev_score} ->
         score =
           if rank == 0 do
             @first_score

--- a/lib/flamingo/scoring.ex
+++ b/lib/flamingo/scoring.ex
@@ -1,10 +1,21 @@
 defmodule Flamingo.Scoring do
+  @first_score 400
   @base_score 300
-  @min_gap 25
+  @rank_decay 0.8
+  @min_gap 10
   @min_score 50
-  @max_time_penalty 250
-  @first_bonus 100
+  @max_time_penalty 100
 
+  @doc """
+  Scores a completed turn.
+
+  Guessers are scored primarily by finishing position so being early feels
+  great: the first guesser always banks #{@first_score}, and each later rank
+  decays multiplicatively from #{@base_score}. A smaller time penalty (up to
+  #{@max_time_penalty}) punishes guesses that trail long after the first
+  correct answer. Scores never increase with rank and never drop below
+  #{@min_score}.
+  """
   def calculate_round_scores(correct_guesses, drawer_id, player_order, turn_length) do
     guesser_scores = calculate_guesser_scores(correct_guesses, turn_length)
 
@@ -45,25 +56,23 @@ defmodule Flamingo.Scoring do
     {scores, _prev} =
       sorted
       |> Enum.with_index()
-      |> Enum.reduce({%{}, nil}, fn {{player_id, guess_time}, idx}, {acc, prev_score} ->
-        time_taken_us = DateTime.diff(guess_time, first_time, :microsecond)
-        time_ratio = time_taken_us / turn_duration_us
-        time_ratio = max(0.0, min(1.0, time_ratio))
-
-        score = @base_score - trunc(@max_time_penalty * time_ratio)
-
+      |> Enum.reduce({%{}, @first_score}, fn {{player_id, guess_time}, rank},
+                                             {acc, prev_score} ->
         score =
-          if idx == 0 do
-            score + @first_bonus
+          if rank == 0 do
+            @first_score
           else
-            if prev_score - score < @min_gap do
-              prev_score - @min_gap
-            else
-              score
-            end
+            time_taken_us = DateTime.diff(guess_time, first_time, :microsecond)
+            time_ratio = time_taken_us / turn_duration_us
+            time_ratio = max(0.0, min(1.0, time_ratio))
+
+            rank_score = trunc(@base_score * :math.pow(@rank_decay, rank))
+
+            (rank_score - trunc(@max_time_penalty * time_ratio))
+            |> min(prev_score - @min_gap)
+            |> max(@min_score)
           end
 
-        score = max(score, @min_score)
         {Map.put(acc, player_id, score), score}
       end)
 

--- a/lib/flamingo_web/components/game_components.ex
+++ b/lib/flamingo_web/components/game_components.ex
@@ -36,8 +36,12 @@ defmodule FlamingoWeb.GameComponents do
     """
   end
 
-  @num_rows 30
-  @num_cols 45
+  # Rows must cover the tallest realistic viewport (portrait QHD ~2560 CSS px)
+  # and columns the widest (4K ~3840 CSS px plus drift animation overshoot),
+  # since the cells are a fixed-size tessellation behind a fixed full-screen
+  # layer.
+  @num_rows 66
+  @num_cols 27
   @row_height_rem 2.5
   @col_width_rem 10
 
@@ -88,25 +92,24 @@ defmodule FlamingoWeb.GameComponents do
   attr :show_timer, :boolean, default: false
 
   def game_header(assigns) do
-    {display, letter_count} =
+    {display, hint_chars, letter_count} =
       case {assigns.word, assigns.show_word} do
         {nil, _} ->
-          {nil, nil}
+          {nil, nil, nil}
 
         {word, true} ->
-          {word, nil}
+          {word, nil, nil}
 
         {word, false} ->
           revealed = MapSet.new(assigns.revealed_indices)
 
-          hint =
+          chars =
             word
             |> String.graphemes()
             |> Enum.with_index()
             |> Enum.map(fn {ch, idx} ->
               if ch == " " or MapSet.member?(revealed, idx), do: ch, else: "_"
             end)
-            |> Enum.join()
 
           count =
             word
@@ -114,10 +117,11 @@ defmodule FlamingoWeb.GameComponents do
             |> Enum.map(&String.length/1)
             |> Enum.join("-")
 
-          {hint, count}
+          {word, chars, count}
       end
 
-    assigns = assign(assigns, display: display, letter_count: letter_count)
+    assigns =
+      assign(assigns, display: display, hint_chars: hint_chars, letter_count: letter_count)
 
     ~H"""
     <div class="relative self-center">
@@ -126,10 +130,21 @@ defmodule FlamingoWeb.GameComponents do
         if(!@display, do: "invisible")
       ]}>
         <div class="flex items-center justify-center gap-4">
-          <p class="font-hero text-5xl leading-none font-black tracking-widest text-white">
-            {if(@display, do: @display, else: Phoenix.HTML.raw("&nbsp;"))}
-          </p>
-          <%= if @display && @letter_count do %>
+          <%= if @hint_chars do %>
+            <p class="flex items-baseline gap-[0.18em] font-hero text-5xl leading-none font-black text-white">
+              <span
+                :for={ch <- @hint_chars}
+                class={["inline-block text-center", ch == " " && "w-[0.45em]"]}
+              >
+                {if(ch == " ", do: "", else: ch)}
+              </span>
+            </p>
+          <% else %>
+            <p class="font-hero text-5xl leading-none font-black tracking-widest text-white">
+              {if(@display, do: @display, else: Phoenix.HTML.raw("&nbsp;"))}
+            </p>
+          <% end %>
+          <%= if @hint_chars && @letter_count do %>
             <p class="font-hero text-2xl leading-none font-bold text-white">{@letter_count}</p>
           <% end %>
         </div>
@@ -161,13 +176,17 @@ defmodule FlamingoWeb.GameComponents do
       <div class="min-h-0 flex-grow overflow-y-auto">
         <ul>
           <%= for pid <- @player_order do %>
+            <% connected = Map.get(Map.get(@players, pid), :connected, true) %>
             <li class={[
-              "flex items-center gap-2 px-3 py-2",
+              "flex items-center gap-2 px-3 py-2 transition-opacity",
               pid == @drawer_id && "bg-pink-100 font-semibold",
-              pid != @drawer_id && MapSet.member?(@correct_guesses, pid) && "bg-green-100"
+              pid != @drawer_id && MapSet.member?(@correct_guesses, pid) && "bg-green-100",
+              !connected && "opacity-40"
             ]}>
               <span class="inline-flex h-5 w-5 shrink-0 items-center justify-center">
                 <%= cond do %>
+                  <% !connected -> %>
+                    <.icon name={:wifi_off} class="h-4 w-4 text-gray-500" />
                   <% pid == @drawer_id -> %>
                     <.icon name={:paintbrush} class="h-4 w-4" />
                   <% MapSet.member?(@correct_guesses, pid) -> %>

--- a/lib/flamingo_web/live/game_live.ex
+++ b/lib/flamingo_web/live/game_live.ex
@@ -16,7 +16,8 @@ defmodule FlamingoWeb.GameLive do
 
   def mount(%{"room_id" => room_id} = _params, _session, socket) do
     {:ok,
-     assign(socket,
+     socket
+     |> assign(
        room_id: room_id,
        player_id: nil,
        phase: :lobby,
@@ -38,98 +39,95 @@ defmodule FlamingoWeb.GameLive do
        correct_guesses: MapSet.new(),
        revealed_indices: [],
        guess_form: to_form(%{"guess" => ""}, as: :guess_form),
-       score_gains: %{},
-       feed: []
-     )}
+       score_gains: %{}
+     )
+     |> stream_configure(:feed, dom_id: &"feed-#{&1.id}")
+     |> stream(:feed, [])}
   end
 
   def handle_params(%{"player_id" => player_id}, _uri, socket) do
     room_id = socket.assigns.room_id
 
     if connected?(socket) do
-      case Games.get_state(room_id) do
+      # Rejoin (rather than just reading state) so a reconnecting player is
+      # marked connected again before their disconnect grace period expires.
+      case Games.rejoin(room_id, player_id) do
         {:ok, state} ->
-          if Map.has_key?(state.players, player_id) do
-            Games.subscribe(room_id)
+          Games.subscribe(room_id)
 
-            word_choices =
-              if state.phase == :word_choice and player_id == state.drawer_id,
-                do: state.word_choices,
-                else: nil
+          word_choices =
+            if state.phase == :word_choice and player_id == state.drawer_id,
+              do: state.word_choices,
+              else: nil
 
-            is_drawer = player_id == state.drawer_id
-            show_word = is_drawer or state.phase == :turn_reveal or state.phase == :game_ended
+          is_drawer = player_id == state.drawer_id
+          show_word = is_drawer or state.phase == :turn_reveal or state.phase == :game_ended
 
-            score_gains =
-              if state.phase == :turn_reveal, do: state.score_gains, else: %{}
+          score_gains =
+            if state.phase == :turn_reveal, do: state.score_gains, else: %{}
 
-            final_players =
-              if state.phase == :game_ended, do: state.players, else: %{}
+          final_players =
+            if state.phase == :game_ended, do: state.players, else: %{}
 
-            final_player_order =
-              if state.phase == :game_ended, do: state.player_order, else: []
+          final_player_order =
+            if state.phase == :game_ended, do: state.player_order, else: []
 
-            final_drawings =
-              if state.phase == :game_ended, do: state.final_drawings, else: []
+          final_drawings =
+            if state.phase == :game_ended, do: state.final_drawings, else: []
 
-            selected_player_id =
-              if state.phase == :game_ended,
-                do: winning_player_id(final_players, final_player_order),
-                else: nil
+          selected_player_id =
+            if state.phase == :game_ended,
+              do: winning_player_id(final_players, final_player_order),
+              else: nil
 
-            socket =
-              assign(socket,
-                player_id: player_id,
-                phase: state.phase,
-                players: state.players,
-                player_order: state.player_order,
-                host_id: state.host_id,
-                drawer_id: state.drawer_id,
-                final_players: final_players,
-                final_player_order: final_player_order,
-                final_drawings: final_drawings,
-                selected_player_id: selected_player_id,
-                round_count: state.round_count,
-                turn_length: state.turn_length,
-                current_round: state.current_round,
-                word_choices: word_choices,
-                turn_end_time: state.turn_end_time,
-                word: state.word,
-                show_word: show_word,
-                correct_guesses: MapSet.new(Map.keys(state.correct_guesses)),
-                revealed_indices: state.revealed_indices,
-                score_gains: score_gains,
-                feed:
-                  state.feed.events
-                  |> Enum.map(&Feed.format(&1, player_id))
-                  |> Enum.reject(&is_nil/1)
-              )
+          socket =
+            socket
+            |> assign(
+              player_id: player_id,
+              phase: state.phase,
+              players: state.players,
+              player_order: state.player_order,
+              host_id: state.host_id,
+              drawer_id: state.drawer_id,
+              final_players: final_players,
+              final_player_order: final_player_order,
+              final_drawings: final_drawings,
+              selected_player_id: selected_player_id,
+              round_count: state.round_count,
+              turn_length: state.turn_length,
+              current_round: state.current_round,
+              word_choices: word_choices,
+              turn_end_time: state.turn_end_time,
+              word: state.word,
+              show_word: show_word,
+              correct_guesses: MapSet.new(Map.keys(state.correct_guesses)),
+              revealed_indices: state.revealed_indices,
+              score_gains: score_gains
+            )
+            |> stream(:feed, formatted_feed(state.feed, player_id), reset: true)
 
-            socket =
-              if state.phase in [:word_choice, :playing, :turn_reveal] and state.turn_end_time do
-                push_event(socket, "set_timer", %{
-                  end_time: DateTime.to_iso8601(state.turn_end_time)
-                })
-              else
-                socket
-              end
-
-            socket =
-              if state.phase == :playing and state.current_drawing != [] do
-                push_event(socket, "drawing_state", %{events: state.current_drawing})
-              else
-                socket
-              end
-
-            socket =
+          socket =
+            if state.phase in [:word_choice, :playing, :turn_reveal] and state.turn_end_time do
+              push_event(socket, "set_timer", %{
+                end_time: DateTime.to_iso8601(state.turn_end_time)
+              })
+            else
               socket
-              |> sync_round_audio()
-              |> push_event("play_sound", %{sound: "join"})
+            end
 
-            {:noreply, socket}
-          else
-            {:noreply, push_navigate(socket, to: ~p"/")}
-          end
+          socket =
+            if state.phase == :playing and state.current_drawing != [] do
+              push_event(socket, "drawing_state", %{events: state.current_drawing})
+            else
+              socket
+            end
+
+          socket =
+            socket
+            |> sync_round_audio()
+            |> push_event("play_sound", %{sound: "join"})
+
+          {:noreply, socket}
 
         {:error, :not_found} ->
           {:noreply, push_navigate(socket, to: ~p"/")}
@@ -144,6 +142,12 @@ defmodule FlamingoWeb.GameLive do
   end
 
   defp palette, do: @palette
+
+  defp formatted_feed(feed, player_id) do
+    feed.events
+    |> Enum.map(&Feed.format(&1, player_id))
+    |> Enum.reject(&is_nil/1)
+  end
 
   defp winning_player_id(players, player_order) do
     Enum.max_by(player_order, fn pid -> Map.get(players, pid).score end, fn -> nil end)
@@ -457,20 +461,22 @@ defmodule FlamingoWeb.GameLive do
                 <div
                   id="game-feed"
                   phx-hook=".ScrollFeed"
+                  phx-update="stream"
                   class="flex min-h-0 flex-1 flex-col gap-0 overflow-y-auto"
                 >
                   <p
-                    :for={{type, text} <- @feed}
+                    :for={{dom_id, entry} <- @streams.feed}
+                    id={dom_id}
                     class={[
                       "p-1 text-xs",
-                      type == :system && "font-semibold text-pink-600",
-                      type == :correct && "font-semibold text-green-600",
-                      type == :close && "font-semibold text-amber-600",
-                      type == :guess && "text-foreground",
-                      type == :info && "text-gray-500"
+                      entry.kind == :system && "font-semibold text-pink-600",
+                      entry.kind == :correct && "font-semibold text-green-600",
+                      entry.kind == :close && "font-semibold text-amber-600",
+                      entry.kind == :guess && "text-foreground",
+                      entry.kind == :info && "text-gray-500"
                     ]}
                   >
-                    {text}
+                    {entry.text}
                   </p>
                 </div>
               </.box>
@@ -583,7 +589,9 @@ defmodule FlamingoWeb.GameLive do
                         phx-update="ignore"
                         data-is-drawer="false"
                         data-final-drawing-replay="true"
-                        data-final-drawing-events={Jason.encode!(drawing.events)}
+                        data-final-drawing-events={
+                          Jason.encode!(DrawingShare.compact_ops(drawing.events))
+                        }
                       >
                         <canvas width="700" height="500" class="aspect-[7/5] w-full bg-white">
                         </canvas>
@@ -646,12 +654,16 @@ defmodule FlamingoWeb.GameLive do
             }
 
             update()
+            // The form (re)mounts when a turn starts drawing; put the player
+            // straight into the input so they can type immediately.
+            input.focus()
             input.addEventListener("input", update)
             this.el.addEventListener("submit", () => {
               // Let LiveView serialize the submitted value before clearing the visible input.
               setTimeout(() => {
                 this.el.reset()
                 update()
+                input.focus()
               }, 0)
             })
           }
@@ -675,14 +687,26 @@ defmodule FlamingoWeb.GameLive do
       <script :type={Phoenix.LiveView.ColocatedHook} name=".ScrollFeed">
         export default {
           mounted() {
+            // Follow new messages only while the user is at (or near) the
+            // bottom; never yank the feed around while they're reading back.
+            this.pinned = true
+            this.el.addEventListener("scroll", () => {
+              const distanceFromBottom =
+                this.el.scrollHeight - this.el.scrollTop - this.el.clientHeight
+              this.pinned = distanceFromBottom < 32
+            })
             this.scrollToBottom()
-            this.handleEvent("scroll_feed", () => this.scrollToBottom())
+            this.handleEvent("scroll_feed", () => this.pinned && this.scrollToBottom())
           },
           updated() {
-            this.scrollToBottom()
+            if (this.pinned) this.scrollToBottom()
           },
           scrollToBottom() {
-            this.el.scrollTop = this.el.scrollHeight
+            // Wait a frame so layout has settled; scrolling while the panel is
+            // mid-patch (height not yet computed) silently clamps to the top.
+            requestAnimationFrame(() => {
+              this.el.scrollTop = this.el.scrollHeight
+            })
           }
         }
       </script>
@@ -758,6 +782,27 @@ defmodule FlamingoWeb.GameLive do
         socket
       ) do
     is_drawer = socket.assigns.player_id == drawer_id
+
+    # The feed container isn't rendered in the lobby or game-end screens, so
+    # any stream items pushed while it was absent never reached the DOM.
+    # Re-seed the stream from the server when the game (re)starts.
+    socket =
+      if socket.assigns.phase in [:lobby, :game_ended] do
+        case Games.get_state(socket.assigns.room_id) do
+          {:ok, state} ->
+            stream(
+              socket,
+              :feed,
+              formatted_feed(state.feed, socket.assigns.player_id),
+              reset: true
+            )
+
+          {:error, :not_found} ->
+            socket
+        end
+      else
+        socket
+      end
 
     socket =
       assign(socket,
@@ -879,16 +924,16 @@ defmodule FlamingoWeb.GameLive do
     end
   end
 
-  def handle_info({:feed_event, event}, socket) do
-    formatted = Feed.format(event, socket.assigns.player_id)
+  def handle_info({:feed_event, entry}, socket) do
+    case Feed.format(entry, socket.assigns.player_id) do
+      nil ->
+        {:noreply, socket}
 
-    if formatted do
-      {:noreply,
-       socket
-       |> assign(:feed, socket.assigns.feed ++ [formatted])
-       |> push_event("scroll_feed", %{})}
-    else
-      {:noreply, socket}
+      item ->
+        {:noreply,
+         socket
+         |> stream_insert(:feed, item)
+         |> push_event("scroll_feed", %{})}
     end
   end
 

--- a/lib/flamingo_web/live/game_live.ex
+++ b/lib/flamingo_web/live/game_live.ex
@@ -652,8 +652,6 @@ defmodule FlamingoWeb.GameLive do
             }
 
             update()
-            // The form (re)mounts when a turn starts drawing; put the player
-            // straight into the input so they can type immediately.
             input.focus()
             input.addEventListener("input", update)
             this.el.addEventListener("submit", () => {

--- a/lib/flamingo_web/live/game_live.ex
+++ b/lib/flamingo_web/live/game_live.ex
@@ -589,9 +589,7 @@ defmodule FlamingoWeb.GameLive do
                         phx-update="ignore"
                         data-is-drawer="false"
                         data-final-drawing-replay="true"
-                        data-final-drawing-events={
-                          Jason.encode!(DrawingShare.compact_ops(drawing.events))
-                        }
+                        data-final-drawing-events={Jason.encode!(drawing.ops)}
                       >
                         <canvas width="700" height="500" class="aspect-[7/5] w-full bg-white">
                         </canvas>

--- a/test/flamingo/drawing_share_test.exs
+++ b/test/flamingo/drawing_share_test.exs
@@ -3,7 +3,7 @@ defmodule Flamingo.DrawingShareTest do
 
   alias Flamingo.DrawingShare
 
-  test "encodes drawings into URL-safe base64 and decodes them" do
+  test "encodes drawings into URL-safe compressed payloads and decodes them" do
     drawing = %{
       drawer_name: "Alice",
       word: "flamingo",
@@ -15,21 +15,140 @@ defmodule Flamingo.DrawingShareTest do
           "y" => 20,
           "color" => "#000000",
           "line_width" => 9
-        }
+        },
+        %{
+          "event_type" => "draw",
+          "start_x" => 10,
+          "start_y" => 20,
+          "end_x" => 30,
+          "end_y" => 40,
+          "color" => "#000000",
+          "line_width" => 9
+        },
+        %{"event_type" => "fill", "x" => 100, "y" => 120, "color" => "#EF120B"},
+        %{"event_type" => "clear"}
       ]
     }
 
     encoded = DrawingShare.encode(drawing)
 
+    assert String.starts_with?(encoded, "z")
     refute encoded =~ "+"
     refute encoded =~ "/"
     refute encoded =~ "="
 
-    assert {:ok, ^drawing} = DrawingShare.decode(encoded)
+    assert {:ok, decoded} = DrawingShare.decode(encoded)
+    assert decoded.drawer_name == "Alice"
+    assert decoded.word == "flamingo"
+    assert decoded.round_number == 2
+
+    assert [
+             %{"event_type" => "start", "x" => 10, "y" => 20},
+             %{
+               "event_type" => "draw",
+               "start_x" => 10,
+               "start_y" => 20,
+               "end_x" => 30,
+               "end_y" => 40
+             },
+             %{"event_type" => "fill", "x" => 100, "y" => 120, "color" => "#EF120B"},
+             %{"event_type" => "clear"}
+           ] = decoded.events
+  end
+
+  test "rounds coordinates and drops sub-pixel jitter" do
+    jittery_points =
+      for i <- 0..99 do
+        %{
+          "event_type" => "draw",
+          "start_x" => 10 + i * 0.1,
+          "start_y" => 20,
+          "end_x" => 10 + (i + 1) * 0.1,
+          "end_y" => 20,
+          "color" => "#000000",
+          "line_width" => 9
+        }
+      end
+
+    drawing = %{
+      drawer_name: "Alice",
+      word: "flamingo",
+      round_number: 1,
+      events:
+        [
+          %{
+            "event_type" => "start",
+            "x" => 10.4,
+            "y" => 20.2,
+            "color" => "#000000",
+            "line_width" => 9
+          }
+        ] ++ jittery_points
+    }
+
+    assert [["p", "#000000", 9, points]] = DrawingShare.compact_ops(drawing.events)
+
+    # 101 raw points collapse to a handful of integer coordinates
+    assert length(points) < 20
+    assert Enum.all?(points, &is_integer/1)
+    # stroke endpoints survive simplification
+    assert Enum.take(points, 2) == [10, 20]
+    assert Enum.take(points, -2) == [20, 20]
+  end
+
+  test "compresses large drawings far below the raw event encoding" do
+    events =
+      [
+        %{"event_type" => "start", "x" => 0, "y" => 0, "color" => "#000000", "line_width" => 9}
+      ] ++
+        for i <- 1..5000 do
+          %{
+            "event_type" => "draw",
+            "start_x" => rem(i - 1, 700) * 1.0,
+            "start_y" => rem((i - 1) * 3, 500) * 1.0,
+            "end_x" => rem(i, 700) * 1.0,
+            "end_y" => rem(i * 3, 500) * 1.0,
+            "color" => "#000000",
+            "line_width" => 9
+          }
+        end
+
+    drawing = %{drawer_name: "Alice", word: "flamingo", round_number: 1, events: events}
+
+    raw_size = drawing |> Jason.encode!() |> byte_size()
+    encoded_size = drawing |> DrawingShare.encode() |> byte_size()
+
+    assert encoded_size < div(raw_size, 10)
+  end
+
+  test "decodes legacy uncompressed links" do
+    payload = %{
+      "drawer_name" => "Alice",
+      "word" => "flamingo",
+      "round_number" => 2,
+      "events" => [
+        %{
+          "event_type" => "start",
+          "x" => 10,
+          "y" => 20,
+          "color" => "#000000",
+          "line_width" => 9
+        }
+      ]
+    }
+
+    encoded = payload |> Jason.encode!() |> Base.url_encode64(padding: false)
+
+    assert {:ok, decoded} = DrawingShare.decode(encoded)
+    assert decoded.drawer_name == "Alice"
+    assert decoded.word == "flamingo"
+    assert decoded.round_number == 2
+    assert [%{"event_type" => "start"}] = decoded.events
   end
 
   test "rejects invalid drawing payloads" do
     assert {:error, :invalid_drawing} = DrawingShare.decode("not-base64")
+    assert {:error, :invalid_drawing} = DrawingShare.decode("znot-valid-zlib")
 
     encoded =
       %{"drawer_name" => "Alice", "word" => "flamingo", "round_number" => 1, "events" => ["bad"]}
@@ -44,5 +163,13 @@ defmodule Flamingo.DrawingShareTest do
       |> Base.url_encode64(padding: false)
 
     assert {:error, :invalid_drawing} = DrawingShare.decode(encoded)
+
+    bad_ops =
+      %{"v" => 2, "n" => "Alice", "w" => "flamingo", "r" => 1, "o" => [["x", 1]]}
+      |> Jason.encode!()
+      |> :zlib.compress()
+      |> Base.url_encode64(padding: false)
+
+    assert {:error, :invalid_drawing} = DrawingShare.decode("z" <> bad_ops)
   end
 end

--- a/test/flamingo/drawing_share_test.exs
+++ b/test/flamingo/drawing_share_test.exs
@@ -3,34 +3,38 @@ defmodule Flamingo.DrawingShareTest do
 
   alias Flamingo.DrawingShare
 
-  test "encodes drawings into URL-safe compressed payloads and decodes them" do
-    drawing = %{
+  defp encode_drawing(events) do
+    DrawingShare.encode(%{
       drawer_name: "Alice",
       word: "flamingo",
       round_number: 2,
-      events: [
-        %{
-          "event_type" => "start",
-          "x" => 10,
-          "y" => 20,
-          "color" => "#000000",
-          "line_width" => 9
-        },
-        %{
-          "event_type" => "draw",
-          "start_x" => 10,
-          "start_y" => 20,
-          "end_x" => 30,
-          "end_y" => 40,
-          "color" => "#000000",
-          "line_width" => 9
-        },
-        %{"event_type" => "fill", "x" => 100, "y" => 120, "color" => "#EF120B"},
-        %{"event_type" => "clear"}
-      ]
-    }
+      ops: DrawingShare.compact_ops(events)
+    })
+  end
 
-    encoded = DrawingShare.encode(drawing)
+  test "encodes drawings into URL-safe compressed payloads and decodes them" do
+    events = [
+      %{
+        "event_type" => "start",
+        "x" => 10,
+        "y" => 20,
+        "color" => "#000000",
+        "line_width" => 9
+      },
+      %{
+        "event_type" => "draw",
+        "start_x" => 10,
+        "start_y" => 20,
+        "end_x" => 30,
+        "end_y" => 40,
+        "color" => "#000000",
+        "line_width" => 9
+      },
+      %{"event_type" => "fill", "x" => 100, "y" => 120, "color" => "#EF120B"},
+      %{"event_type" => "clear"}
+    ]
+
+    encoded = encode_drawing(events)
 
     assert String.starts_with?(encoded, "z")
     refute encoded =~ "+"
@@ -56,47 +60,79 @@ defmodule Flamingo.DrawingShareTest do
            ] = decoded.events
   end
 
-  test "rounds coordinates and drops sub-pixel jitter" do
+  test "strokes are delta-encoded and simplified down to their shape" do
     jittery_points =
       for i <- 0..99 do
         %{
           "event_type" => "draw",
-          "start_x" => 10 + i * 0.1,
-          "start_y" => 20,
-          "end_x" => 10 + (i + 1) * 0.1,
-          "end_y" => 20,
+          "start_x" => 10 + i * 2.0,
+          "start_y" => 20 + rem(i, 2) * 0.4,
+          "end_x" => 10 + (i + 1) * 2.0,
+          "end_y" => 20 + rem(i + 1, 2) * 0.4,
           "color" => "#000000",
           "line_width" => 9
         }
       end
 
-    drawing = %{
-      drawer_name: "Alice",
-      word: "flamingo",
-      round_number: 1,
-      events:
+    events =
+      [
+        %{
+          "event_type" => "start",
+          "x" => 10.4,
+          "y" => 20.2,
+          "color" => "#000000",
+          "line_width" => 9
+        }
+      ] ++ jittery_points
+
+    # A jittery near-straight line collapses to its two endpoints,
+    # delta-encoded: [x0, y0, dx, dy].
+    assert [["p", "#000000", 9, [10, 20, 200, 0]]] = DrawingShare.compact_ops(events)
+  end
+
+  test "total points are capped so busy drawings stay small" do
+    # 40 dense wavy strokes: thousands of raw points, but each wave flattens
+    # to a couple of points once the tolerance escalates.
+    wave = fn stroke, i -> 250 + stroke * 2 + :math.sin(i / 10) * 20 end
+
+    events =
+      Enum.flat_map(1..40, fn stroke ->
         [
           %{
             "event_type" => "start",
-            "x" => 10.4,
-            "y" => 20.2,
+            "x" => 10,
+            "y" => wave.(stroke, 0),
             "color" => "#000000",
             "line_width" => 9
           }
-        ] ++ jittery_points
-    }
+          | for i <- 1..200 do
+              %{
+                "event_type" => "draw",
+                "start_x" => 10 + (i - 1) * 3,
+                "start_y" => wave.(stroke, i - 1),
+                "end_x" => 10 + i * 3,
+                "end_y" => wave.(stroke, i),
+                "color" => "#000000",
+                "line_width" => 9
+              }
+            end
+        ]
+      end)
 
-    assert [["p", "#000000", 9, points]] = DrawingShare.compact_ops(drawing.events)
+    ops = DrawingShare.compact_ops(events)
 
-    # 101 raw points collapse to a handful of integer coordinates
-    assert length(points) < 20
-    assert Enum.all?(points, &is_integer/1)
-    # stroke endpoints survive simplification
-    assert Enum.take(points, 2) == [10, 20]
-    assert Enum.take(points, -2) == [20, 20]
+    total_points =
+      ops
+      |> Enum.map(fn
+        ["p", _color, _width, nums] -> div(length(nums), 2)
+        _op -> 0
+      end)
+      |> Enum.sum()
+
+    assert total_points <= 200
   end
 
-  test "compresses large drawings far below the raw event encoding" do
+  test "compresses large drawings by 100x or more" do
     events =
       [
         %{"event_type" => "start", "x" => 0, "y" => 0, "color" => "#000000", "line_width" => 9}
@@ -113,12 +149,11 @@ defmodule Flamingo.DrawingShareTest do
           }
         end
 
-    drawing = %{drawer_name: "Alice", word: "flamingo", round_number: 1, events: events}
+    raw_size = events |> Jason.encode!() |> byte_size()
+    encoded_size = events |> encode_drawing() |> byte_size()
 
-    raw_size = drawing |> Jason.encode!() |> byte_size()
-    encoded_size = drawing |> DrawingShare.encode() |> byte_size()
-
-    assert encoded_size < div(raw_size, 10)
+    assert encoded_size < div(raw_size, 100)
+    assert encoded_size < 2048
   end
 
   test "decodes legacy uncompressed links" do

--- a/test/flamingo/game_server_test.exs
+++ b/test/flamingo/game_server_test.exs
@@ -109,7 +109,7 @@ defmodule Flamingo.GameServerTest do
     assert state.phase == :word_choice
   end
 
-  test "minimum turn length schedules first hint before the turn ends", %{room_id: room_id} do
+  test "minimum turn length schedules hints before the turn ends", %{room_id: room_id} do
     {:ok, p1, _} = GameServer.join(room_id, "Alice")
     {:ok, _p2, _} = GameServer.join(room_id, "Bob")
     :ok = GameServer.start_game(room_id, p1, %{turn_length: 15})
@@ -121,8 +121,43 @@ defmodule Flamingo.GameServerTest do
     {:ok, state} = GameServer.get_state(room_id)
 
     assert is_reference(state.hint_timer_ref)
-    assert GameServer.first_hint_delay_ms(15) == 10_000
-    assert GameServer.first_hint_delay_ms(30) == 20_000
+
+    schedule = GameServer.hint_schedule(word, 15)
+    assert schedule != []
+    assert Enum.all?(schedule, &(&1 < 15_000))
+  end
+
+  test "hint schedule spreads reveals across the turn for every round length" do
+    for turn_length <- [15, 30, 45, 120] do
+      schedule = GameServer.hint_schedule("flamingo", turn_length)
+      turn_ms = turn_length * 1000
+
+      # 8 letters -> up to half revealed
+      assert length(schedule) == 4
+      assert schedule == Enum.sort(schedule)
+      assert Enum.all?(schedule, &(&1 >= trunc(turn_ms * 0.3)))
+      assert Enum.all?(schedule, &(&1 < turn_ms))
+    end
+  end
+
+  test "hint schedule reveals at most half the letters" do
+    assert length(GameServer.hint_schedule("cat", 45)) == 1
+    assert length(GameServer.hint_schedule("Pac-Man", 45)) == 3
+    assert GameServer.hint_schedule("a", 45) == []
+  end
+
+  test "hints reveal letters while playing", %{room_id: room_id} do
+    Phoenix.PubSub.subscribe(Flamingo.PubSub, "game:#{room_id}")
+    {_p1, _p2, word, state} = start_playing(room_id)
+
+    pid = GenServer.whereis({:via, Registry, {Flamingo.GameRegistry, room_id}})
+    send(pid, {:reveal_hint, state.hint_timer_ref})
+
+    assert_receive {:hint_revealed, [index]}
+    assert index in 0..(String.length(word) - 1)
+
+    {:ok, state} = GameServer.get_state(room_id)
+    assert state.revealed_indices == [index]
   end
 
   test "turn reveal clears pending hint timer", %{room_id: room_id} do
@@ -151,6 +186,142 @@ defmodule Flamingo.GameServerTest do
 
   test "rejoin fails for unknown player", %{room_id: room_id} do
     assert {:error, :not_found} = GameServer.rejoin(room_id, "nonexistent")
+  end
+
+  test "leave during a game marks the player disconnected instead of removing them", %{
+    room_id: room_id
+  } do
+    {p1, p2, _word, state} = start_playing(room_id)
+    guesser = if p1 == state.drawer_id, do: p2, else: p1
+
+    :ok = GameServer.leave(room_id, guesser)
+
+    {:ok, state} = GameServer.get_state(room_id)
+    assert Map.has_key?(state.players, guesser)
+    refute Map.get(state.players, guesser).connected
+    assert guesser in state.player_order
+    assert is_reference(Map.get(state.disconnect_timers, guesser))
+  end
+
+  test "rejoin reconnects a disconnected player", %{room_id: room_id} do
+    {p1, p2, _word, state} = start_playing(room_id)
+    guesser = if p1 == state.drawer_id, do: p2, else: p1
+
+    :ok = GameServer.leave(room_id, guesser)
+    {:ok, state} = GameServer.rejoin(room_id, guesser)
+
+    assert Map.get(state.players, guesser).connected
+    refute Map.has_key?(state.disconnect_timers, guesser)
+  end
+
+  test "disconnected players are removed once the grace period expires", %{room_id: room_id} do
+    {:ok, p1, _} = GameServer.join(room_id, "Alice")
+    {:ok, p2, _} = GameServer.join(room_id, "Bob")
+    {:ok, p3, _} = GameServer.join(room_id, "Charlie")
+    :ok = GameServer.start_game(room_id, p1, %{round_count: 1, turn_length: 30})
+
+    {:ok, state} = GameServer.get_state(room_id)
+    word = List.first(state.word_choices)
+    :ok = GameServer.select_word(room_id, state.drawer_id, word)
+
+    {:ok, state} = GameServer.get_state(room_id)
+    guesser = Enum.find([p1, p2, p3], &(&1 != state.drawer_id))
+
+    :ok = GameServer.leave(room_id, guesser)
+
+    {:ok, state} = GameServer.get_state(room_id)
+    ref = Map.fetch!(state.disconnect_timers, guesser)
+
+    pid = GenServer.whereis({:via, Registry, {Flamingo.GameRegistry, room_id}})
+    send(pid, {:remove_player, guesser, ref})
+    _ = :sys.get_state(pid)
+
+    {:ok, state} = GameServer.get_state(room_id)
+    refute Map.has_key?(state.players, guesser)
+    refute guesser in state.player_order
+  end
+
+  test "a reconnected player is not removed by the stale grace timer", %{room_id: room_id} do
+    {p1, p2, _word, state} = start_playing(room_id)
+    guesser = if p1 == state.drawer_id, do: p2, else: p1
+
+    :ok = GameServer.leave(room_id, guesser)
+
+    {:ok, state} = GameServer.get_state(room_id)
+    ref = Map.fetch!(state.disconnect_timers, guesser)
+
+    {:ok, _state} = GameServer.rejoin(room_id, guesser)
+
+    pid = GenServer.whereis({:via, Registry, {Flamingo.GameRegistry, room_id}})
+    send(pid, {:remove_player, guesser, ref})
+    _ = :sys.get_state(pid)
+
+    {:ok, state} = GameServer.get_state(room_id)
+    assert Map.has_key?(state.players, guesser)
+    assert Map.get(state.players, guesser).connected
+  end
+
+  test "a disconnected guesser keeps their earned score", %{room_id: room_id} do
+    {:ok, p1, _} = GameServer.join(room_id, "Alice")
+    {:ok, p2, _} = GameServer.join(room_id, "Bob")
+    {:ok, p3, _} = GameServer.join(room_id, "Charlie")
+    :ok = GameServer.start_game(room_id, p1, %{round_count: 1, turn_length: 30})
+
+    {:ok, state} = GameServer.get_state(room_id)
+    word = List.first(state.word_choices)
+    :ok = GameServer.select_word(room_id, state.drawer_id, word)
+
+    {:ok, state} = GameServer.get_state(room_id)
+    [g1, g2] = Enum.reject([p1, p2, p3], &(&1 == state.drawer_id))
+
+    :correct = GameServer.guess(room_id, g1, word)
+    :ok = GameServer.leave(room_id, g1)
+    :correct = GameServer.guess(room_id, g2, word)
+
+    {:ok, state} = GameServer.get_state(room_id)
+    assert state.phase == :turn_reveal
+    assert Map.get(state.players, g1).score > 0
+
+    {:ok, state} = GameServer.rejoin(room_id, g1)
+    assert Map.get(state.players, g1).score > 0
+    assert Map.get(state.players, g1).connected
+  end
+
+  test "next drawer skips disconnected players", %{room_id: room_id} do
+    {:ok, p1, _} = GameServer.join(room_id, "Alice")
+    {:ok, p2, _} = GameServer.join(room_id, "Bob")
+    {:ok, p3, _} = GameServer.join(room_id, "Charlie")
+    :ok = GameServer.start_game(room_id, p1, %{round_count: 1, turn_length: 30})
+
+    {:ok, state} = GameServer.get_state(room_id)
+    word = List.first(state.word_choices)
+    :ok = GameServer.select_word(room_id, state.drawer_id, word)
+
+    {:ok, state} = GameServer.get_state(room_id)
+    [g1, g2] = Enum.reject([p1, p2, p3], &(&1 == state.drawer_id))
+
+    :correct = GameServer.guess(room_id, g1, word)
+    :correct = GameServer.guess(room_id, g2, word)
+
+    {:ok, state} = GameServer.get_state(room_id)
+    assert state.phase == :turn_reveal
+
+    # The next drawer in order disconnects during the reveal
+    next_in_order =
+      Enum.find(state.player_order, fn pid ->
+        not MapSet.member?(state.drawn_this_round, pid)
+      end)
+
+    :ok = GameServer.leave(room_id, next_in_order)
+
+    pid = GenServer.whereis({:via, Registry, {Flamingo.GameRegistry, room_id}})
+    {:ok, state} = GameServer.get_state(room_id)
+    send(pid, {:turn_reveal_timeout, state.phase_timer_ref})
+    _ = :sys.get_state(pid)
+
+    {:ok, state} = GameServer.get_state(room_id)
+    assert state.phase == :word_choice
+    assert state.drawer_id != next_in_order
   end
 
   defp start_playing(room_id, settings \\ %{round_count: 1, turn_length: 30}) do
@@ -203,10 +374,10 @@ defmodule Flamingo.GameServerTest do
     assert :close = GameServer.guess(room_id, guesser, close_guess)
 
     refute_receive {:incorrect_guess, ^guesser, ^close_guess}
-    assert_receive {:feed_event, {:close_guess, ^guesser} = event}
+    assert_receive {:feed_event, %{event: {:close_guess, ^guesser}} = entry}
 
-    assert {:close, "You were close"} = Flamingo.Feed.format(event, guesser)
-    assert nil == Flamingo.Feed.format(event, other_player)
+    assert %{kind: :close, text: "You were close"} = Flamingo.Feed.format(entry, guesser)
+    assert nil == Flamingo.Feed.format(entry, other_player)
   end
 
   test "close guess ignores case spacing and punctuation for same-length typos", %{
@@ -227,7 +398,7 @@ defmodule Flamingo.GameServerTest do
     assert :close = GameServer.guess(room_id, guesser, close_guess)
 
     refute_receive {:incorrect_guess, ^guesser, ^close_guess}
-    assert_receive {:feed_event, {:close_guess, ^guesser}}
+    assert_receive {:feed_event, %{event: {:close_guess, ^guesser}}}
   end
 
   test "wrong-length guesses are normal incorrect guesses", %{room_id: room_id} do
@@ -239,7 +410,7 @@ defmodule Flamingo.GameServerTest do
     assert :incorrect = GameServer.guess(room_id, guesser, wrong_length_guess)
 
     assert_receive {:incorrect_guess, ^guesser, ^wrong_length_guess}
-    refute_receive {:feed_event, {:close_guess, ^guesser}}
+    refute_receive {:feed_event, %{event: {:close_guess, ^guesser}}}
   end
 
   test "one-character insertion is a close guess", %{room_id: room_id} do
@@ -251,7 +422,7 @@ defmodule Flamingo.GameServerTest do
     assert :close = GameServer.guess(room_id, guesser, close_guess)
 
     refute_receive {:incorrect_guess, ^guesser, ^close_guess}
-    assert_receive {:feed_event, {:close_guess, ^guesser}}
+    assert_receive {:feed_event, %{event: {:close_guess, ^guesser}}}
   end
 
   test "one-character deletion is a close guess", %{room_id: room_id} do
@@ -263,7 +434,7 @@ defmodule Flamingo.GameServerTest do
     assert :close = GameServer.guess(room_id, guesser, close_guess)
 
     refute_receive {:incorrect_guess, ^guesser, ^close_guess}
-    assert_receive {:feed_event, {:close_guess, ^guesser}}
+    assert_receive {:feed_event, %{event: {:close_guess, ^guesser}}}
   end
 
   test "drawer cannot guess", %{room_id: room_id} do

--- a/test/flamingo/game_server_test.exs
+++ b/test/flamingo/game_server_test.exs
@@ -499,12 +499,14 @@ defmodule Flamingo.GameServerTest do
 
     {:ok, state} = GameServer.get_state(room_id)
 
+    # Drawings are kept as compact ops (delta-encoded polylines), not raw
+    # events.
     assert [
              %{
                drawer_id: ^drawer,
                word: ^word,
                round_number: 1,
-               events: [^start_event, ^draw_event]
+               ops: [["p", "#000000", 9, [10, 20, 20, 20]]]
              }
            ] = state.final_drawings
   end
@@ -523,7 +525,7 @@ defmodule Flamingo.GameServerTest do
                drawer_id: ^drawer,
                word: ^word,
                round_number: 1,
-               events: []
+               ops: []
              }
            ] = state.final_drawings
   end

--- a/test/flamingo/scoring_test.exs
+++ b/test/flamingo/scoring_test.exs
@@ -1,0 +1,95 @@
+defmodule Flamingo.ScoringTest do
+  use ExUnit.Case, async: true
+
+  alias Flamingo.Scoring
+
+  @turn_length 45
+
+  defp guess_times(offsets_ms) do
+    base = ~U[2026-01-01 12:00:00.000000Z]
+
+    offsets_ms
+    |> Enum.with_index()
+    |> Map.new(fn {offset, idx} ->
+      {"player-#{idx}", DateTime.add(base, offset, :millisecond)}
+    end)
+  end
+
+  test "first guesser always gets the full first score" do
+    scores =
+      Scoring.calculate_round_scores(
+        guess_times([0]),
+        "drawer",
+        ["drawer", "player-0"],
+        @turn_length
+      )
+
+    assert scores["player-0"] == 400
+  end
+
+  test "early ranks are rewarded steeply" do
+    guesses = guess_times([0, 500, 1_000, 1_500, 2_000])
+    order = ["drawer" | Map.keys(guesses)]
+
+    scores = Scoring.calculate_round_scores(guesses, "drawer", order, @turn_length)
+
+    assert scores["player-0"] == 400
+    # near-immediate follow-ups keep most of their rank score
+    assert scores["player-1"] in 230..240
+    assert scores["player-2"] in 180..192
+    assert scores["player-3"] in 145..154
+    assert scores["player-4"] in 115..123
+  end
+
+  test "scores never increase with rank" do
+    guesses = guess_times([0, 40_000, 40_500, 41_000, 42_000, 43_000])
+    order = ["drawer" | Map.keys(guesses)]
+
+    scores = Scoring.calculate_round_scores(guesses, "drawer", order, @turn_length)
+
+    ranked =
+      guesses
+      |> Enum.sort_by(fn {_id, time} -> DateTime.to_unix(time, :microsecond) end)
+      |> Enum.map(fn {id, _} -> scores[id] end)
+
+    assert ranked == Enum.sort(ranked, :desc)
+  end
+
+  test "slow guesses are penalised but floored" do
+    guesses = guess_times([0, 44_000])
+    order = ["drawer" | Map.keys(guesses)]
+
+    scores = Scoring.calculate_round_scores(guesses, "drawer", order, @turn_length)
+
+    assert scores["player-0"] == 400
+    # rank score 240 minus nearly the full time penalty
+    assert scores["player-1"] <= 145
+    assert scores["player-1"] >= 50
+  end
+
+  test "very late stragglers bottom out at the minimum" do
+    guesses = guess_times(Enum.map(0..9, &(&1 * 4_000)))
+    order = ["drawer" | Map.keys(guesses)]
+
+    scores = Scoring.calculate_round_scores(guesses, "drawer", order, @turn_length)
+
+    last = scores["player-9"]
+    assert last == 50
+  end
+
+  test "drawer scoring scales with how many players guessed" do
+    order = ["drawer", "a", "b", "c"]
+
+    assert %{"drawer" => -100} =
+             Scoring.calculate_round_scores(%{}, "drawer", order, @turn_length)
+
+    one = guess_times([0]) |> Scoring.calculate_round_scores("drawer", order, @turn_length)
+    assert one["drawer"] == 100
+
+    all =
+      guess_times([0, 1_000, 2_000])
+      |> Scoring.calculate_round_scores("drawer", order, @turn_length)
+
+    assert all["drawer"] == 350
+  end
+end


### PR DESCRIPTION
This PR improves several aspects of the game experience: hint reveal timing, player disconnection resilience, and drawing share link efficiency.

## Summary

Refactors hint scheduling to spread letter reveals evenly across each turn regardless of length, adds graceful handling for temporarily disconnected players, and implements compact drawing encoding with zlib compression for share links.

## Key Changes

**Hint Scheduling**
- Replace fixed-interval hint timing with `hint_schedule/2` that spreads reveals evenly across the middle 35-90% of each turn
- Reveals up to half the word's letters, ensuring shorter rounds and longer words both get useful hints
- Eliminates the old `first_hint_delay_ms/1` function

**Disconnection Handling**
- Add `connected` flag to player struct; disconnected players are marked rather than immediately removed
- Implement 60-second grace period (`@disconnect_grace_ms`) before removing disconnected players, allowing reconnection via `rejoin`
- Track disconnect timers in state to prevent stale removal messages
- Refactor leave logic: immediate removal only in lobby/game_ended phases; during active play, mark as disconnected
- Add `reconcile_turn_completion/2` to check if all connected guessers have answered when a player disconnects

**Drawing Compression**
- Implement `compact_ops/1` to reduce raw draw events to compact ops: simplified polylines (delta-encoded), fills, and clears
- Use Ramer-Douglas-Peucker algorithm to simplify strokes within a point budget (200 total points)
- Escalate tolerance through `@epsilon_steps` until drawing fits, trading fidelity for size on busy sketches
- Compress with zlib and base64url-encode, prefixed with "z" to distinguish from legacy links
- Implement `expand_ops/1` to convert compact ops back to renderable events
- Add `opsToEvents` TypeScript helper for client-side decompression
- Typical drawings compress to ~1KB

**Feed and Scoring**
- Add `id` field to feed entries for streaming support in LiveView
- Refactor scoring to use multiplicative rank decay (`@rank_decay = 0.8`) instead of fixed gaps
- Adjust score constants: `@first_score = 400`, reduce `@max_time_penalty` to 100, `@min_gap` to 10

**UI/UX**
- Update game header to show both hint characters and letter count separately
- Adjust background tessellation grid dimensions for better coverage on modern viewports (66 rows × 27 cols)
- Convert feed to LiveView stream for efficient incremental updates
- Use `rejoin` instead of `get_state` on reconnect to mark player connected before grace period expires

## Notable Implementation Details

- Hint scheduling uses fractional positioning within the window to distribute reveals evenly: `turn_ms * (@hint_window_start + window * (k - 0.5) / max_reveals)`
- Disconnection grace period is enforced via process message with reference matching to prevent race conditions
- Drawing simplification is iterative: if a stroke doesn't fit the point budget at one tolerance, the next epsilon step is tried
- Delta encoding of polylines keeps coordinate numbers small for better compression
- Legacy uncompressed drawing links (plain base64url JSON) remain supported for backward compatibility

https://claude.ai/code/session_016r8pcFZZYaCm65kChE736U