### PR TITLE
Allow hosts to use custom word lists

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -133,6 +133,44 @@
   }
 }
 
+.nb-checkbox {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 1.25rem;
+  height: 1.25rem;
+  flex-shrink: 0;
+  border: 2px solid var(--foreground);
+  background-color: white;
+  cursor: pointer;
+  position: relative;
+}
+
+.nb-checkbox:checked {
+  background-color: var(--primary);
+}
+
+.nb-checkbox:checked::after {
+  content: "";
+  position: absolute;
+  left: 0.3rem;
+  top: 0.08rem;
+  width: 0.35rem;
+  height: 0.65rem;
+  border-right: 2px solid var(--foreground);
+  border-bottom: 2px solid var(--foreground);
+  transform: rotate(45deg);
+}
+
+.nb-checkbox:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.nb-checkbox:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
 .nb-switch {
   -webkit-appearance: none;
   appearance: none;

--- a/lib/flamingo/game_server.ex
+++ b/lib/flamingo/game_server.ex
@@ -32,6 +32,8 @@ defmodule Flamingo.GameServer do
     drawn_this_round: MapSet.new(),
     current_drawing: [],
     word_choices: [],
+    custom_words: [],
+    include_default_words: false,
     used_words: MapSet.new(),
     correct_guesses: %{},
     revealed_indices: [],
@@ -154,11 +156,17 @@ defmodule Flamingo.GameServer do
   def handle_call({:start_game, player_id, settings}, _from, state) do
     round_count = Map.get(settings, :round_count, state.round_count)
     turn_length = Map.get(settings, :turn_length, state.turn_length)
+    custom_words = Map.get(settings, :custom_words, state.custom_words)
+
+    include_default_words =
+      Map.get(settings, :include_default_words, state.include_default_words)
 
     with :ok <- validate_host(state, player_id),
          :ok <- validate_player_count(state),
          :ok <- validate_round_count(round_count),
-         :ok <- validate_turn_length(turn_length) do
+         :ok <- validate_turn_length(turn_length),
+         {:ok, custom_words} <- Flamingo.Words.validate_custom_words(custom_words),
+         :ok <- validate_include_default_words(include_default_words) do
       drawer_id = List.first(state.player_order)
 
       new_state =
@@ -166,6 +174,8 @@ defmodule Flamingo.GameServer do
           state
           | round_count: round_count,
             turn_length: turn_length,
+            custom_words: custom_words,
+            include_default_words: include_default_words,
             drawer_id: drawer_id,
             current_round: 0,
             drawn_this_round: MapSet.new(),
@@ -436,7 +446,10 @@ defmodule Flamingo.GameServer do
   end
 
   defp enter_word_choice(state) do
-    word_choices = Flamingo.Words.random_choices(3, state.used_words)
+    words =
+      Flamingo.Words.available_words(state.custom_words, state.include_default_words)
+
+    word_choices = Flamingo.Words.random_choices(3, state.used_words, words)
 
     if word_choices == [] do
       enter_game_ended(state)
@@ -624,6 +637,9 @@ defmodule Flamingo.GameServer do
        do: :ok
 
   defp validate_turn_length(_), do: {:error, :invalid_turn_length}
+
+  defp validate_include_default_words(value) when is_boolean(value), do: :ok
+  defp validate_include_default_words(_value), do: {:error, :invalid_include_default_words}
 
   defp generate_player_id do
     :crypto.strong_rand_bytes(8) |> Base.url_encode64(padding: false)

--- a/lib/flamingo/game_server.ex
+++ b/lib/flamingo/game_server.ex
@@ -446,10 +446,11 @@ defmodule Flamingo.GameServer do
   end
 
   defp enter_word_choice(state) do
-    words =
-      Flamingo.Words.available_words(state.custom_words, state.include_default_words)
-
-    word_choices = Flamingo.Words.random_choices(3, state.used_words, words)
+    word_choices =
+      Flamingo.Words.random_choices(3, state.used_words,
+        custom_words: state.custom_words,
+        include_default_words: state.include_default_words
+      )
 
     if word_choices == [] do
       enter_game_ended(state)

--- a/lib/flamingo/words.ex
+++ b/lib/flamingo/words.ex
@@ -4,16 +4,21 @@ defmodule Flamingo.Words do
   @words File.read!("priv/words/default.txt")
          |> String.split("\n", trim: true)
 
-  def random_choices(n \\ 3, excluded_words \\ MapSet.new(), words \\ @words) do
+  def random_choices(n \\ 3, excluded_words \\ MapSet.new(), options \\ []) do
+    custom_words = Keyword.get(options, :custom_words, [])
+    include_default_words = Keyword.get(options, :include_default_words, false)
+
+    words = available_words(custom_words, include_default_words)
+
     words
     |> Enum.reject(&MapSet.member?(excluded_words, &1))
     |> Enum.take_random(n)
   end
 
-  def available_words([], _include_default_words), do: @words
-  def available_words(custom_words, false), do: custom_words
+  defp available_words([], _include_default_words), do: @words
+  defp available_words(custom_words, false), do: custom_words
 
-  def available_words(custom_words, true) do
+  defp available_words(custom_words, true) do
     Enum.uniq_by(custom_words ++ @words, &String.downcase/1)
   end
 

--- a/lib/flamingo/words.ex
+++ b/lib/flamingo/words.ex
@@ -1,10 +1,48 @@
 defmodule Flamingo.Words do
+  @max_custom_words 1_000
+
   @words File.read!("priv/words/default.txt")
          |> String.split("\n", trim: true)
 
-  def random_choices(n \\ 3, excluded_words \\ MapSet.new()) do
-    @words
+  def random_choices(n \\ 3, excluded_words \\ MapSet.new(), words \\ @words) do
+    words
     |> Enum.reject(&MapSet.member?(excluded_words, &1))
     |> Enum.take_random(n)
   end
+
+  def available_words([], _include_default_words), do: @words
+  def available_words(custom_words, false), do: custom_words
+
+  def available_words(custom_words, true) do
+    Enum.uniq_by(custom_words ++ @words, &String.downcase/1)
+  end
+
+  def parse_custom_words(text) when is_binary(text) do
+    words =
+      text
+      |> String.split(~r/\R/)
+      |> Enum.map(&String.trim/1)
+      |> Enum.reject(&(&1 == ""))
+      |> Enum.uniq()
+
+    validate_custom_words(words)
+  end
+
+  def validate_custom_words(words) when is_list(words) do
+    cond do
+      length(words) > @max_custom_words ->
+        {:error, :too_many_custom_words}
+
+      Enum.any?(
+        words,
+        &(not is_binary(&1) or &1 == "" or String.contains?(&1, [",", "\n", "\r"]))
+      ) ->
+        {:error, :invalid_custom_words}
+
+      true ->
+        {:ok, words}
+    end
+  end
+
+  def validate_custom_words(_words), do: {:error, :invalid_custom_words}
 end

--- a/lib/flamingo_web/components/core_components.ex
+++ b/lib/flamingo_web/components/core_components.ex
@@ -88,7 +88,9 @@ defmodule FlamingoWeb.CoreComponents do
       <.button phx-click="go" variant="primary">Send!</.button>
       <.button navigate={~p"/"}>Home</.button>
   """
-  attr :rest, :global, include: ~w(href navigate patch method download name value disabled type)
+  attr :rest, :global,
+    include: ~w(href navigate patch method download name value disabled type form)
+
   attr :class, :any, default: nil
   attr :variant, :string, default: "default", values: ~w(default neutral ghost outline)
   attr :size, :string, default: "default", values: ~w(default sm icon)
@@ -290,16 +292,17 @@ defmodule FlamingoWeb.CoreComponents do
           disabled={@rest[:disabled]}
           form={@rest[:form]}
         />
-        <span class="label">
+        <span class="flex cursor-pointer items-center gap-2 text-sm text-foreground">
           <input
             type="checkbox"
             id={@id}
             name={@name}
             value="true"
             checked={@checked}
-            class={@class || "checkbox checkbox-sm"}
+            class={@class || "nb-checkbox"}
             {@rest}
-          />{@label}
+          />
+          <span>{@label}</span>
         </span>
       </label>
       <.error :for={msg <- @errors}>{msg}</.error>

--- a/lib/flamingo_web/endpoint.ex
+++ b/lib/flamingo_web/endpoint.ex
@@ -5,11 +5,14 @@ defmodule FlamingoWeb.Endpoint do
   # this means its contents can be read but not tampered with.
   # Set :encryption_salt if you would also like to encrypt it.
   @session_options [
-    store: :cookie,
-    key: "_flamingo_key",
-    signing_salt: "Hnq1ZvWb",
-    same_site: "Lax"
-  ]
+                     store: :cookie,
+                     key: "_flamingo_key",
+                     signing_salt: "Hnq1ZvWb"
+                   ] ++
+                     if(System.get_env("PUBLIC_URL"),
+                       do: [same_site: "None", secure: true],
+                       else: [same_site: "Lax"]
+                     )
 
   socket "/live", Phoenix.LiveView.Socket,
     websocket: [connect_info: [session: @session_options]],

--- a/lib/flamingo_web/live/game_live.ex
+++ b/lib/flamingo_web/live/game_live.ex
@@ -1,7 +1,7 @@
 defmodule FlamingoWeb.GameLive do
   use FlamingoWeb, :live_view
 
-  alias Flamingo.{DrawingShare, Feed, Games}
+  alias Flamingo.{DrawingShare, Feed, Games, Words}
 
   @min_turn_length 15
   @max_turn_length 120
@@ -31,6 +31,19 @@ defmodule FlamingoWeb.GameLive do
        drawer_id: nil,
        round_count: 3,
        turn_length: 45,
+       custom_words: "",
+       custom_word_count: 0,
+       custom_words_error: nil,
+       settings_form:
+         to_form(
+           %{
+             "round_count" => "3",
+             "turn_length" => "45",
+             "custom_words" => "",
+             "include_default_words" => false
+           },
+           as: :settings
+         ),
        word_choices: nil,
        turn_end_time: nil,
        word: nil,
@@ -95,6 +108,19 @@ defmodule FlamingoWeb.GameLive do
               selected_player_id: selected_player_id,
               round_count: state.round_count,
               turn_length: state.turn_length,
+              custom_words: Enum.join(state.custom_words, "\n"),
+              custom_word_count: length(state.custom_words),
+              custom_words_error: nil,
+              settings_form:
+                to_form(
+                  %{
+                    "round_count" => Integer.to_string(state.round_count),
+                    "turn_length" => Integer.to_string(state.turn_length),
+                    "custom_words" => Enum.join(state.custom_words, "\n"),
+                    "include_default_words" => state.include_default_words
+                  },
+                  as: :settings
+                ),
               current_round: state.current_round,
               word_choices: word_choices,
               turn_end_time: state.turn_end_time,
@@ -211,8 +237,14 @@ defmodule FlamingoWeb.GameLive do
             </div>
 
             <%= if @player_id == @host_id do %>
-              <div class="flex h-full w-full flex-[3] flex-col gap-4 p-4">
-                <.form for={%{}} as={:settings} phx-change="update_settings" id="settings-form">
+              <div class="flex h-full min-h-0 w-full flex-[3] flex-col overflow-hidden">
+                <.form
+                  for={@settings_form}
+                  phx-change="update_settings"
+                  phx-submit="start_game"
+                  class="min-h-0 flex-1 overflow-y-auto p-4"
+                  id="settings-form"
+                >
                   <div class="space-y-1">
                     <div class="flex w-full justify-between">
                       <label class="text-sm">Rounds</label>
@@ -223,7 +255,7 @@ defmodule FlamingoWeb.GameLive do
                       min="1"
                       max="5"
                       value={@round_count}
-                      name="settings[round_count]"
+                      name={@settings_form[:round_count].name}
                       class="nb-slider w-full"
                       style={"--slider-progress: #{(@round_count - 1) / 4 * 100}%"}
                       phx-hook=".RoundSlider"
@@ -239,15 +271,51 @@ defmodule FlamingoWeb.GameLive do
                         min={@min_turn_length}
                         max={@max_turn_length}
                         value={@turn_length}
-                        name="settings[turn_length]"
+                        name={@settings_form[:turn_length].name}
                         class="w-full rounded-base border-2 border-border bg-white px-3 py-2 text-sm focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-none"
                         id="round-length-input"
                       />
                     </div>
                   </div>
+
+                  <div class="mt-4">
+                    <div class="flex items-end justify-between gap-3">
+                      <label for="custom-words-input" class="text-sm">Custom words</label>
+                      <span id="custom-word-count" class="text-xs text-gray-500">
+                        {@custom_word_count} / 1000
+                      </span>
+                    </div>
+                    <.input
+                      field={@settings_form[:custom_words]}
+                      type="textarea"
+                      rows="4"
+                      placeholder={"Add your own words, one per line" <> "\nflamingo\nsandcastle"}
+                      class="mt-1 min-h-24 w-full resize-y rounded-base border-2 border-border bg-white px-3 py-2 text-sm leading-5 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-none"
+                      phx-hook=".CustomWords"
+                      id="custom-words-input"
+                    />
+                    <p
+                      :if={@custom_words_error}
+                      id="custom-words-error"
+                      class="mt-1 text-xs text-red-600"
+                    >
+                      {@custom_words_error}
+                    </p>
+                    <p :if={!@custom_words_error} class="mt-1 text-xs text-gray-500">
+                      Leave empty to use the standard word list. Commas are not supported.
+                    </p>
+                    <div class="mt-3">
+                      <.input
+                        field={@settings_form[:include_default_words]}
+                        type="checkbox"
+                        label="Include standard words"
+                        id="include-default-words-input"
+                      />
+                    </div>
+                  </div>
                 </.form>
 
-                <div class="mt-auto flex w-full flex-col gap-4">
+                <div class="flex w-full shrink-0 flex-col gap-4 border-t-2 border-border p-4">
                   <div>
                     <label class="text-sm">Room name</label>
                     <div class="flex flex-row items-center justify-between">
@@ -277,7 +345,8 @@ defmodule FlamingoWeb.GameLive do
 
                   <.button
                     variant="default"
-                    phx-click="start_game"
+                    type="submit"
+                    form="settings-form"
                     disabled={map_size(@players) < 2}
                     id="start-game-button"
                   >
@@ -680,6 +749,31 @@ defmodule FlamingoWeb.GameLive do
           }
         }
       </script>
+      <script :type={Phoenix.LiveView.ColocatedHook} name=".CustomWords">
+        export default {
+          mounted() {
+            this.validate = () => {
+              const words = this.el.value.split(/\r?\n/).map(word => word.trim()).filter(Boolean)
+              const message = this.el.value.includes(",")
+                ? "Enter one word per line without commas."
+                : words.length > 1000
+                  ? "Custom word lists can contain at most 1000 words."
+                  : ""
+
+              this.el.setCustomValidity(message)
+            }
+
+            this.validate()
+            this.el.addEventListener("input", this.validate)
+          },
+          updated() {
+            this.validate()
+          },
+          destroyed() {
+            this.el.removeEventListener("input", this.validate)
+          }
+        }
+      </script>
       <script :type={Phoenix.LiveView.ColocatedHook} name=".ScrollFeed">
         export default {
           mounted() {
@@ -711,7 +805,7 @@ defmodule FlamingoWeb.GameLive do
   end
 
   def handle_event("update_settings", %{"settings" => params}, socket) do
-    round_count = String.to_integer(params["round_count"])
+    round_count = parse_integer(params["round_count"], socket.assigns.round_count)
 
     turn_length =
       case Integer.parse(params["turn_length"]) do
@@ -719,21 +813,50 @@ defmodule FlamingoWeb.GameLive do
         :error -> socket.assigns.turn_length
       end
 
-    {:noreply, assign(socket, round_count: round_count, turn_length: turn_length)}
+    custom_words = Map.get(params, "custom_words", "")
+    {custom_word_count, custom_words_error} = custom_words_summary(custom_words)
+
+    {:noreply,
+     assign(socket,
+       round_count: round_count,
+       turn_length: turn_length,
+       custom_words: custom_words,
+       custom_word_count: custom_word_count,
+       custom_words_error: custom_words_error,
+       settings_form: to_form(params, as: :settings)
+     )}
   end
 
-  def handle_event("start_game", _params, socket) do
-    settings = %{
-      round_count: socket.assigns.round_count,
-      turn_length: socket.assigns.turn_length
-    }
+  def handle_event("start_game", %{"settings" => params}, socket) do
+    custom_words = Map.get(params, "custom_words", "")
 
-    case Games.start_game(socket.assigns.room_id, socket.assigns.player_id, settings) do
-      :ok ->
-        {:noreply, socket}
+    case Words.parse_custom_words(custom_words) do
+      {:ok, words} ->
+        settings = %{
+          round_count: socket.assigns.round_count,
+          turn_length: socket.assigns.turn_length,
+          custom_words: words,
+          include_default_words: params["include_default_words"] == "true"
+        }
 
-      {:error, reason} ->
-        {:noreply, put_flash(socket, :error, "Cannot start game: #{reason}")}
+        case Games.start_game(socket.assigns.room_id, socket.assigns.player_id, settings) do
+          :ok ->
+            {:noreply, socket}
+
+          {:error, reason} ->
+            {:noreply, put_flash(socket, :error, "Cannot start game: #{reason}")}
+        end
+
+      {:error, _reason} ->
+        {custom_word_count, custom_words_error} = custom_words_summary(custom_words)
+
+        {:noreply,
+         assign(socket,
+           custom_words: custom_words,
+           custom_word_count: custom_word_count,
+           custom_words_error: custom_words_error,
+           settings_form: to_form(params, as: :settings)
+         )}
     end
   end
 
@@ -754,6 +877,32 @@ defmodule FlamingoWeb.GameLive do
 
   def handle_event("select_player", %{"player-id" => player_id}, socket) do
     {:noreply, assign(socket, selected_player_id: player_id)}
+  end
+
+  defp parse_integer(value, fallback) do
+    case Integer.parse(value || "") do
+      {parsed, _} -> parsed
+      :error -> fallback
+    end
+  end
+
+  defp custom_words_summary(custom_words) do
+    case Words.parse_custom_words(custom_words) do
+      {:ok, words} ->
+        {length(words), nil}
+
+      {:error, :too_many_custom_words} ->
+        {custom_word_line_count(custom_words), "Use at most 1000 custom words."}
+
+      {:error, :invalid_custom_words} ->
+        {custom_word_line_count(custom_words), "Enter one word per line without commas."}
+    end
+  end
+
+  defp custom_word_line_count(custom_words) do
+    custom_words
+    |> String.split(~r/\R/)
+    |> Enum.count(&(String.trim(&1) != ""))
   end
 
   def handle_info({:players_updated, players, player_order, host_id}, socket) do

--- a/test/flamingo/game_server_test.exs
+++ b/test/flamingo/game_server_test.exs
@@ -109,6 +109,48 @@ defmodule Flamingo.GameServerTest do
     assert state.phase == :word_choice
   end
 
+  test "start_game uses custom words exclusively", %{room_id: room_id} do
+    {:ok, p1, _} = GameServer.join(room_id, "Alice")
+    {:ok, _p2, _} = GameServer.join(room_id, "Bob")
+    custom_words = ["orbital llama", "velvet cactus", "disco teapot"]
+
+    assert :ok = GameServer.start_game(room_id, p1, %{custom_words: custom_words})
+
+    {:ok, state} = GameServer.get_state(room_id)
+    assert state.custom_words == custom_words
+    assert Enum.sort(state.word_choices) == Enum.sort(custom_words)
+  end
+
+  test "start_game can include deduplicated default words with custom words", %{room_id: room_id} do
+    {:ok, p1, _} = GameServer.join(room_id, "Alice")
+    {:ok, _p2, _} = GameServer.join(room_id, "Bob")
+
+    assert :ok =
+             GameServer.start_game(room_id, p1, %{
+               custom_words: ["apple", "orbital llama"],
+               include_default_words: true
+             })
+
+    {:ok, state} = GameServer.get_state(room_id)
+    words = Flamingo.Words.available_words(state.custom_words, state.include_default_words)
+
+    assert state.include_default_words
+    assert "orbital llama" in words
+    refute "Apple" in words
+    assert length(Enum.filter(words, &(String.downcase(&1) == "apple"))) == 1
+  end
+
+  test "start_game rejects invalid custom words", %{room_id: room_id} do
+    {:ok, p1, _} = GameServer.join(room_id, "Alice")
+    {:ok, _p2, _} = GameServer.join(room_id, "Bob")
+
+    assert {:error, :invalid_custom_words} =
+             GameServer.start_game(room_id, p1, %{custom_words: ["cat, dog"]})
+
+    assert {:error, :too_many_custom_words} =
+             GameServer.start_game(room_id, p1, %{custom_words: Enum.map(1..1001, &"word #{&1}")})
+  end
+
   test "minimum turn length schedules hints before the turn ends", %{room_id: room_id} do
     {:ok, p1, _} = GameServer.join(room_id, "Alice")
     {:ok, _p2, _} = GameServer.join(room_id, "Bob")

--- a/test/flamingo/game_server_test.exs
+++ b/test/flamingo/game_server_test.exs
@@ -132,12 +132,10 @@ defmodule Flamingo.GameServerTest do
              })
 
     {:ok, state} = GameServer.get_state(room_id)
-    words = Flamingo.Words.available_words(state.custom_words, state.include_default_words)
 
     assert state.include_default_words
-    assert "orbital llama" in words
-    refute "Apple" in words
-    assert length(Enum.filter(words, &(String.downcase(&1) == "apple"))) == 1
+    assert state.custom_words == ["apple", "orbital llama"]
+    assert length(state.word_choices) == 3
   end
 
   test "start_game rejects invalid custom words", %{room_id: room_id} do

--- a/test/flamingo/words_test.exs
+++ b/test/flamingo/words_test.exs
@@ -18,13 +18,16 @@ defmodule Flamingo.WordsTest do
     assert Words.random_choices(3, excluded_words) == []
   end
 
-  test "available_words merges defaults and deduplicates case-insensitively" do
-    words = Words.available_words(["apple", "orbital llama"], true)
+  test "random_choices merges defaults and deduplicates case-insensitively" do
+    excluded_words = all_words() |> Enum.reject(&(&1 in ["Apple", "bow"])) |> MapSet.new()
 
-    assert "apple" in words
-    assert "orbital llama" in words
-    refute "Apple" in words
-    assert length(Enum.filter(words, &(String.downcase(&1) == "apple"))) == 1
+    choices =
+      Words.random_choices(3, excluded_words,
+        custom_words: ["Bow", "orbital llama"],
+        include_default_words: true
+      )
+
+    assert Enum.sort(choices) == Enum.sort(["Apple", "Bow", "orbital llama"])
   end
 
   test "parse_custom_words trims blank lines and removes duplicates" do

--- a/test/flamingo/words_test.exs
+++ b/test/flamingo/words_test.exs
@@ -18,6 +18,27 @@ defmodule Flamingo.WordsTest do
     assert Words.random_choices(3, excluded_words) == []
   end
 
+  test "available_words merges defaults and deduplicates case-insensitively" do
+    words = Words.available_words(["apple", "orbital llama"], true)
+
+    assert "apple" in words
+    assert "orbital llama" in words
+    refute "Apple" in words
+    assert length(Enum.filter(words, &(String.downcase(&1) == "apple"))) == 1
+  end
+
+  test "parse_custom_words trims blank lines and removes duplicates" do
+    assert {:ok, ["red panda", "flamingo"]} =
+             Words.parse_custom_words(" red panda \n\nflamingo\nred panda\n")
+  end
+
+  test "parse_custom_words rejects commas and more than 1000 words" do
+    assert {:error, :invalid_custom_words} = Words.parse_custom_words("cat, dog")
+
+    too_many_words = Enum.map_join(1..1001, "\n", &"word #{&1}")
+    assert {:error, :too_many_custom_words} = Words.parse_custom_words(too_many_words)
+  end
+
   defp all_words do
     "priv/words/default.txt"
     |> File.read!()

--- a/test/flamingo_web/live/game_live_test.exs
+++ b/test/flamingo_web/live/game_live_test.exs
@@ -32,6 +32,50 @@ defmodule FlamingoWeb.GameLiveTest do
     assert has_element?(view, "#round-length-input[value='120']")
   end
 
+  test "host can configure custom words one per line", %{conn: conn, room_id: room_id} do
+    {:ok, p1, _} = GameServer.join(room_id, "Alice")
+    {:ok, _p2, _} = GameServer.join(room_id, "Bob")
+
+    {:ok, view, _html} = live(conn, ~p"/game/#{room_id}?player_id=#{p1}")
+
+    assert has_element?(view, "#custom-words-input[placeholder*='one per line']")
+    assert has_element?(view, "#include-default-words-input:not(:checked)")
+
+    view
+    |> form("#settings-form", %{
+      "settings" => %{
+        "round_count" => "3",
+        "turn_length" => "45",
+        "custom_words" => "orbital llama\nvelvet cactus\ndisco teapot",
+        "include_default_words" => "true"
+      }
+    })
+    |> render_submit()
+
+    {:ok, state} = GameServer.get_state(room_id)
+    assert state.custom_words == ["orbital llama", "velvet cactus", "disco teapot"]
+    assert state.include_default_words
+  end
+
+  test "custom word validation is shown before starting", %{conn: conn, room_id: room_id} do
+    {:ok, p1, _} = GameServer.join(room_id, "Alice")
+    {:ok, _p2, _} = GameServer.join(room_id, "Bob")
+
+    {:ok, view, _html} = live(conn, ~p"/game/#{room_id}?player_id=#{p1}")
+
+    view
+    |> element("#settings-form")
+    |> render_change(%{
+      "settings" => %{
+        "round_count" => "3",
+        "turn_length" => "45",
+        "custom_words" => "cat, dog"
+      }
+    })
+
+    assert has_element?(view, "#custom-words-error")
+  end
+
   test "game end screen keeps final scores visible after a player leaves", %{
     conn: conn,
     room_id: room_id


### PR DESCRIPTION
Hosts need a way to tailor drawing prompts for themed or private games instead of always relying on the built-in dictionary. This adds a lobby setting for newline-separated custom words, caps lists at 1,000 entries, and optionally merges the standard dictionary while removing case-insensitive duplicates.

The settings region scrolls independently so resizing a custom list cannot hide the room controls or Start Game action. Portal-hosted development sessions use a secure cross-site cookie because Amp embeds the preview on a different origin.