### PR TITLE
Bump max custom word list size from 1000 to 3000

### DIFF
--- a/lib/flamingo/words.ex
+++ b/lib/flamingo/words.ex
@@ -1,5 +1,5 @@
 defmodule Flamingo.Words do
-  @max_custom_words 1_000
+  @max_custom_words 3_000
 
   @words File.read!("priv/words/default.txt")
          |> String.split("\n", trim: true)

--- a/lib/flamingo_web/live/game_live.ex
+++ b/lib/flamingo_web/live/game_live.ex
@@ -282,7 +282,7 @@ defmodule FlamingoWeb.GameLive do
                     <div class="flex items-end justify-between gap-3">
                       <label for="custom-words-input" class="text-sm">Custom words</label>
                       <span id="custom-word-count" class="text-xs text-gray-500">
-                        {@custom_word_count} / 1000
+                        {@custom_word_count} / 3000
                       </span>
                     </div>
                     <.input
@@ -756,8 +756,8 @@ defmodule FlamingoWeb.GameLive do
               const words = this.el.value.split(/\r?\n/).map(word => word.trim()).filter(Boolean)
               const message = this.el.value.includes(",")
                 ? "Enter one word per line without commas."
-                : words.length > 1000
-                  ? "Custom word lists can contain at most 1000 words."
+                : words.length > 3000
+                  ? "Custom word lists can contain at most 3000 words."
                   : ""
 
               this.el.setCustomValidity(message)
@@ -892,7 +892,7 @@ defmodule FlamingoWeb.GameLive do
         {length(words), nil}
 
       {:error, :too_many_custom_words} ->
-        {custom_word_line_count(custom_words), "Use at most 1000 custom words."}
+        {custom_word_line_count(custom_words), "Use at most 3000 custom words."}
 
       {:error, :invalid_custom_words} ->
         {custom_word_line_count(custom_words), "Enter one word per line without commas."}

--- a/test/flamingo/game_server_test.exs
+++ b/test/flamingo/game_server_test.exs
@@ -146,7 +146,7 @@ defmodule Flamingo.GameServerTest do
              GameServer.start_game(room_id, p1, %{custom_words: ["cat, dog"]})
 
     assert {:error, :too_many_custom_words} =
-             GameServer.start_game(room_id, p1, %{custom_words: Enum.map(1..1001, &"word #{&1}")})
+             GameServer.start_game(room_id, p1, %{custom_words: Enum.map(1..3001, &"word #{&1}")})
   end
 
   test "minimum turn length schedules hints before the turn ends", %{room_id: room_id} do

--- a/test/flamingo/words_test.exs
+++ b/test/flamingo/words_test.exs
@@ -35,10 +35,10 @@ defmodule Flamingo.WordsTest do
              Words.parse_custom_words(" red panda \n\nflamingo\nred panda\n")
   end
 
-  test "parse_custom_words rejects commas and more than 1000 words" do
+  test "parse_custom_words rejects commas and more than 3000 words" do
     assert {:error, :invalid_custom_words} = Words.parse_custom_words("cat, dog")
 
-    too_many_words = Enum.map_join(1..1001, "\n", &"word #{&1}")
+    too_many_words = Enum.map_join(1..3001, "\n", &"word #{&1}")
     assert {:error, :too_many_custom_words} = Words.parse_custom_words(too_many_words)
   end
 


### PR DESCRIPTION
Players can now add up to 3000 custom words instead of the previous 1000 limit. This updates the server-side validation, the LiveView counter display, and both client- and server-side validation messages to reflect the new maximum.