### PR TITLE
Show the guessed word in close feedback

### DIFF
--- a/lib/flamingo/feed.ex
+++ b/lib/flamingo/feed.ex
@@ -11,7 +11,7 @@ defmodule Flamingo.Feed do
 
   def guess(feed, player_id, name, text), do: add(feed, {:guess, player_id, name, text})
 
-  def close_guess(feed, player_id), do: add(feed, {:close_guess, player_id})
+  def close_guess(feed, player_id, guess), do: add(feed, {:close_guess, player_id, guess})
 
   def correct_guess(feed, player_id, name), do: add(feed, {:correct_guess, player_id, name})
 
@@ -37,10 +37,10 @@ defmodule Flamingo.Feed do
 
   defp format_event({:guess, _player_id, name, text}, _viewer), do: {:guess, "#{name}: #{text}"}
 
-  defp format_event({:close_guess, player_id}, viewer) when player_id == viewer,
-    do: {:close, "You were close"}
+  defp format_event({:close_guess, player_id, guess}, viewer) when player_id == viewer,
+    do: {:close, "#{guess} was close!"}
 
-  defp format_event({:close_guess, _player_id}, _viewer), do: nil
+  defp format_event({:close_guess, _player_id, _guess}, _viewer), do: nil
 
   defp format_event({:correct_guess, player_id, _name}, viewer) when player_id == viewer,
     do: {:correct, "You guessed it"}

--- a/lib/flamingo/game_server.ex
+++ b/lib/flamingo/game_server.ex
@@ -237,7 +237,7 @@ defmodule Flamingo.GameServer do
         {:reply, :correct, new_state}
 
       close_guess?(text, state.word) ->
-        {feed, entry} = Feed.close_guess(state.feed, player_id)
+        {feed, entry} = Feed.close_guess(state.feed, player_id, text)
         new_state = %{state | feed: feed}
         broadcast(state.room_id, {:feed_event, entry})
         {:reply, :close, new_state}

--- a/test/flamingo/game_server_test.exs
+++ b/test/flamingo/game_server_test.exs
@@ -437,9 +437,14 @@ defmodule Flamingo.GameServerTest do
     assert :close = GameServer.guess(room_id, guesser, close_guess)
 
     refute_receive {:incorrect_guess, ^guesser, ^close_guess}
-    assert_receive {:feed_event, %{event: {:close_guess, ^guesser}} = entry}
+    assert_receive {:feed_event, %{event: {:close_guess, ^guesser, ^close_guess}} = entry}
 
-    assert %{kind: :close, text: "You were close"} = Flamingo.Feed.format(entry, guesser)
+    assert Flamingo.Feed.format(entry, guesser) == %{
+             id: entry.id,
+             kind: :close,
+             text: "#{close_guess} was close!"
+           }
+
     assert nil == Flamingo.Feed.format(entry, other_player)
   end
 
@@ -461,7 +466,7 @@ defmodule Flamingo.GameServerTest do
     assert :close = GameServer.guess(room_id, guesser, close_guess)
 
     refute_receive {:incorrect_guess, ^guesser, ^close_guess}
-    assert_receive {:feed_event, %{event: {:close_guess, ^guesser}}}
+    assert_receive {:feed_event, %{event: {:close_guess, ^guesser, ^close_guess}}}
   end
 
   test "wrong-length guesses are normal incorrect guesses", %{room_id: room_id} do
@@ -473,7 +478,7 @@ defmodule Flamingo.GameServerTest do
     assert :incorrect = GameServer.guess(room_id, guesser, wrong_length_guess)
 
     assert_receive {:incorrect_guess, ^guesser, ^wrong_length_guess}
-    refute_receive {:feed_event, %{event: {:close_guess, ^guesser}}}
+    refute_receive {:feed_event, %{event: {:close_guess, ^guesser, _guess}}}
   end
 
   test "one-character insertion is a close guess", %{room_id: room_id} do
@@ -485,7 +490,7 @@ defmodule Flamingo.GameServerTest do
     assert :close = GameServer.guess(room_id, guesser, close_guess)
 
     refute_receive {:incorrect_guess, ^guesser, ^close_guess}
-    assert_receive {:feed_event, %{event: {:close_guess, ^guesser}}}
+    assert_receive {:feed_event, %{event: {:close_guess, ^guesser, ^close_guess}}}
   end
 
   test "one-character deletion is a close guess", %{room_id: room_id} do
@@ -497,7 +502,7 @@ defmodule Flamingo.GameServerTest do
     assert :close = GameServer.guess(room_id, guesser, close_guess)
 
     refute_receive {:incorrect_guess, ^guesser, ^close_guess}
-    assert_receive {:feed_event, %{event: {:close_guess, ^guesser}}}
+    assert_receive {:feed_event, %{event: {:close_guess, ^guesser, ^close_guess}}}
   end
 
   test "drawer cannot guess", %{room_id: room_id} do


### PR DESCRIPTION
Close guesses currently show generic feedback, which makes it unclear which submitted guess was nearly correct. Include the submitted guess in the private close-feedback message while keeping the secret word hidden from other players.