### PR TITLE
Flow turn results into columns

### DIFF
--- a/lib/flamingo_web/live/game_live.ex
+++ b/lib/flamingo_web/live/game_live.ex
@@ -432,14 +432,17 @@ defmodule FlamingoWeb.GameLive do
                   <div class="relative flex w-[704px] shrink-0 flex-col gap-4">
                     <%= if @phase == :turn_reveal do %>
                       <div class="absolute inset-x-0 top-0 z-10 m-[2px] flex h-[500px] items-center justify-center bg-white/75 text-center backdrop-blur-[2px]">
-                        <div class="flex w-80 flex-col items-center gap-4">
+                        <div class="flex w-full flex-col items-center gap-4 px-6">
                           <div>
                             <p class="text-xl font-black">The word was</p>
                             <p class="font-hero text-5xl leading-none font-black text-pink-400">
                               {@word}
                             </p>
                           </div>
-                          <ul class="w-64 space-y-1">
+                          <ul
+                            id="turn-reveal-score-gains"
+                            class="grid w-fit grid-flow-col grid-rows-5 auto-cols-[18rem] gap-x-4 gap-y-1"
+                          >
                             <%= for {pid, gain} <- Enum.sort_by(@score_gains, fn {_pid, g} -> -g end) do %>
                               <li
                                 id={"score-gain-row-#{pid}"}

--- a/test/flamingo_web/live/game_live_test.exs
+++ b/test/flamingo_web/live/game_live_test.exs
@@ -325,6 +325,41 @@ defmodule FlamingoWeb.GameLiveTest do
     assert is_binary(reveal_end_time)
   end
 
+  test "turn reveal score gains flow into columns after five players", %{
+    conn: conn,
+    room_id: room_id
+  } do
+    {:ok, player_id, _} = GameServer.join(room_id, "Alice")
+    {:ok, view, _html} = live(conn, ~p"/game/#{room_id}?player_id=#{player_id}")
+
+    players =
+      2..6
+      |> Map.new(fn index ->
+        id = "player-#{index}"
+        {id, %{id: id, name: "Player #{index}", score: 0}}
+      end)
+      |> Map.put(player_id, %{id: player_id, name: "Alice", score: 0, connected: true})
+
+    score_gains =
+      players
+      |> Map.keys()
+      |> Map.new(fn id -> {id, 50} end)
+
+    send(
+      view.pid,
+      {:turn_reveal, "quicksand", DateTime.add(DateTime.utc_now(), 5), score_gains, players}
+    )
+
+    assert has_element?(
+             view,
+             "#turn-reveal-score-gains.grid.grid-flow-col.grid-rows-5"
+           )
+
+    for id <- Map.keys(players) do
+      assert has_element?(view, "#score-gain-row-#{id}")
+    end
+  end
+
   defp play_turn(room_id, p1, p2, drawing_events \\ []) do
     {:ok, state} = GameServer.get_state(room_id)
     word = List.first(state.word_choices)


### PR DESCRIPTION
Long turn-reveal score lists can extend beyond the available overlay height and crowd the countdown. This keeps the results readable by flowing them into a second column after five players while retaining fixed-width rows for aligned names and scores.