### PR TITLE
Widen final scoreboard

### DIFF
--- a/lib/flamingo_web/live/game_live.ex
+++ b/lib/flamingo_web/live/game_live.ex
@@ -581,7 +581,7 @@ defmodule FlamingoWeb.GameLive do
           ) %>
         <% selected_drawings = drawings_for_player(@final_drawings, selected_player_id) %>
         <div class="flex h-screen w-full items-center justify-center">
-          <div class="grid h-full w-fit grid-cols-[320px_320px] items-center justify-center gap-28">
+          <div class="grid h-full w-fit grid-cols-[500px_320px] items-center justify-center gap-28">
             <.card class="flex h-fit w-full flex-col items-center gap-6 bg-white p-8">
               <h2 class="text-3xl font-bold">Game finished</h2>
               <ul


### PR DESCRIPTION
Player names were being truncated in the game-finished standings. Give the scoreboard more horizontal room while leaving the drawing showcase width unchanged.