### PR TITLE
Show round progress during games

### DIFF
--- a/lib/flamingo_web/components/game_components.ex
+++ b/lib/flamingo_web/components/game_components.ex
@@ -378,46 +378,56 @@ defmodule FlamingoWeb.GameComponents do
   attr :player_order, :list, required: true
   attr :drawer_id, :string, default: nil
   attr :correct_guesses, :any, default: MapSet.new()
+  attr :current_round, :integer, required: true
+  attr :round_count, :integer, required: true
 
   def player_list_panel(assigns) do
     ~H"""
-    <.box class="flex w-full flex-1 flex-col bg-white p-0">
-      <div id="player-list-scroll" class="min-h-0 flex-grow overflow-y-auto overflow-x-hidden">
-        <ul>
-          <%= for pid <- @player_order do %>
-            <% connected = Map.get(Map.get(@players, pid), :connected, true) %>
-            <li
-              id={"player-row-#{pid}"}
-              class={[
-                "flex min-w-0 items-center gap-2 px-3 py-2 transition-opacity",
-                pid == @drawer_id && "bg-pink-100 font-semibold",
-                pid != @drawer_id && MapSet.member?(@correct_guesses, pid) && "bg-green-100",
-                !connected && "opacity-40"
-              ]}
-            >
-              <.flamingo_avatar
-                avatar={Map.get(Map.get(@players, pid), :avatar, %{})}
-                class="h-10 w-10 shrink-0"
-                label={"#{Map.get(@players, pid).name}'s avatar"}
-              />
-              <span class="inline-flex h-5 w-5 shrink-0 items-center justify-center">
-                <%= cond do %>
-                  <% !connected -> %>
-                    <.icon name={:wifi_off} class="h-4 w-4 text-gray-500" />
-                  <% pid == @drawer_id -> %>
-                    <.icon name={:paintbrush} class="h-4 w-4" />
-                  <% MapSet.member?(@correct_guesses, pid) -> %>
-                    <.icon name={:check} class="h-4 w-4 text-green-600" />
-                  <% true -> %>
-                <% end %>
-              </span>
-              <span class="min-w-0 flex-1 truncate">{Map.get(@players, pid).name}</span>
-              <span class="shrink-0 text-sm font-semibold">{Map.get(@players, pid).score}</span>
-            </li>
-          <% end %>
-        </ul>
-      </div>
-    </.box>
+    <div class="relative flex w-full flex-1 flex-col">
+      <p
+        id="round-progress"
+        class="absolute -top-8 left-1 text-xl leading-none font-black text-black"
+      >
+        Round {@current_round} of {@round_count}
+      </p>
+      <.box class="flex min-h-0 flex-1 flex-col bg-white p-0">
+        <div id="player-list-scroll" class="min-h-0 flex-grow overflow-y-auto overflow-x-hidden">
+          <ul>
+            <%= for pid <- @player_order do %>
+              <% connected = Map.get(Map.get(@players, pid), :connected, true) %>
+              <li
+                id={"player-row-#{pid}"}
+                class={[
+                  "flex min-w-0 items-center gap-2 px-3 py-2 transition-opacity",
+                  pid == @drawer_id && "bg-pink-100 font-semibold",
+                  pid != @drawer_id && MapSet.member?(@correct_guesses, pid) && "bg-green-100",
+                  !connected && "opacity-40"
+                ]}
+              >
+                <.flamingo_avatar
+                  avatar={Map.get(Map.get(@players, pid), :avatar, %{})}
+                  class="h-10 w-10 shrink-0"
+                  label={"#{Map.get(@players, pid).name}'s avatar"}
+                />
+                <span class="inline-flex h-5 w-5 shrink-0 items-center justify-center">
+                  <%= cond do %>
+                    <% !connected -> %>
+                      <.icon name={:wifi_off} class="h-4 w-4 text-gray-500" />
+                    <% pid == @drawer_id -> %>
+                      <.icon name={:paintbrush} class="h-4 w-4" />
+                    <% MapSet.member?(@correct_guesses, pid) -> %>
+                      <.icon name={:check} class="h-4 w-4 text-green-600" />
+                    <% true -> %>
+                  <% end %>
+                </span>
+                <span class="min-w-0 flex-1 truncate">{Map.get(@players, pid).name}</span>
+                <span class="shrink-0 text-sm font-semibold">{Map.get(@players, pid).score}</span>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+      </.box>
+    </div>
     """
   end
 

--- a/lib/flamingo_web/live/scribble_live.ex
+++ b/lib/flamingo_web/live/scribble_live.ex
@@ -303,6 +303,8 @@ defmodule FlamingoWeb.ScribbleLive do
                 player_order={@player_order}
                 drawer_id={@drawer_id}
                 correct_guesses={@correct_guesses}
+                current_round={@current_round + 1}
+                round_count={@round_count}
               />
 
               <%= cond do %>

--- a/test/flamingo_web/live/scribble_live_test.exs
+++ b/test/flamingo_web/live/scribble_live_test.exs
@@ -185,6 +185,7 @@ defmodule FlamingoWeb.ScribbleLiveTest do
 
     :ok = start_game_as(room_id, p1_token, %{round_count: 1, turn_length: 30})
 
+    assert has_element?(view, "#round-progress.font-black", "Round 1 of 1")
     assert has_element?(view, "#player-list-scroll.overflow-y-auto.overflow-x-hidden")
 
     for player_id <- [p1, p2] do


### PR DESCRIPTION
Players currently have no indication of how far they are through a game. This adds a compact, bold round counter above the player list so progress stays visible without reducing the list's available space.