### PR TITLE
Restore original shared slider styling

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -215,96 +215,39 @@
   animation: starburst-pulse 2s ease-in-out infinite;
 }
 
-.range-input {
+.nb-slider {
   -webkit-appearance: none;
   appearance: none;
-  height: 28px;
-  border: 0;
-  background: transparent;
+  height: 12px;
+  border: 2px solid var(--foreground);
+  border-radius: 0;
+  background: linear-gradient(to right, var(--color-pink-300) var(--slider-progress, 50%), white var(--slider-progress, 50%));
   cursor: pointer;
   margin: 0;
   padding: 0;
 }
 
-.range-input::-webkit-slider-runnable-track {
-  height: 10px;
-  border: 2px solid var(--foreground);
-  border-radius: 9999px;
-  background: linear-gradient(to right, var(--color-pink-400) var(--range-progress, 50%), white var(--range-progress, 50%));
-}
-
-.range-input::-webkit-slider-thumb {
+.nb-slider::-webkit-slider-thumb {
   -webkit-appearance: none;
   appearance: none;
-  width: 22px;
-  height: 22px;
-  margin-top: -6px;
+  width: 16px;
+  height: 16px;
   border-radius: 50%;
   background: white;
   border: 2px solid var(--foreground);
-  box-shadow: 2px 2px 0 var(--foreground);
   cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
-.range-input::-moz-range-track {
-  height: 6px;
-  border: 2px solid var(--foreground);
-  border-radius: 9999px;
-  background: white;
-}
-
-.range-input::-moz-range-progress {
-  height: 6px;
-  border: 2px solid var(--foreground);
-  border-radius: 9999px 0 0 9999px;
-  background: var(--color-pink-400);
-}
-
-.range-input::-moz-range-thumb {
-  width: 18px;
-  height: 18px;
+.nb-slider::-moz-range-thumb {
+  width: 16px;
+  height: 16px;
   border-radius: 50%;
   background: white;
   border: 2px solid var(--foreground);
-  box-shadow: 2px 2px 0 var(--foreground);
   cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
-.range-input:hover::-webkit-slider-thumb {
-  transform: scale(1.08);
-}
-
-.range-input:hover::-moz-range-thumb {
-  transform: scale(1.08);
-}
-
-.range-input:focus-visible {
-  outline: none;
-}
-
-.range-input:focus-visible::-webkit-slider-thumb {
-  outline: 3px solid var(--color-yellow-300);
-  outline-offset: 2px;
-}
-
-.range-input:focus-visible::-moz-range-thumb {
-  outline: 3px solid var(--color-yellow-300);
-  outline-offset: 2px;
-}
-
-.range-input:active::-webkit-slider-thumb {
-  transform: scale(0.96);
-  box-shadow: 1px 1px 0 var(--foreground);
-}
-
-.range-input:active::-moz-range-thumb {
-  transform: scale(0.96);
-  box-shadow: 1px 1px 0 var(--foreground);
-}
-
-.range-input:disabled {
-  cursor: not-allowed;
-  opacity: 0.5;
+.nb-slider::-moz-range-progress {
+  background: var(--color-pink-300);
+  height: 100%;
 }

--- a/lib/flamingo_web/components/core_components.ex
+++ b/lib/flamingo_web/components/core_components.ex
@@ -359,7 +359,7 @@ defmodule FlamingoWeb.CoreComponents do
     assigns =
       assigns
       |> assign(:value, value)
-      |> assign(:range_progress, range_progress(value, min, max))
+      |> assign(:slider_progress, range_progress(value, min, max))
 
     ~H"""
     <div class="fieldset">
@@ -369,8 +369,8 @@ defmodule FlamingoWeb.CoreComponents do
         name={@name}
         id={@id}
         value={@value}
-        class={["range-input", @class || "w-full"]}
-        style={"--range-progress: #{@range_progress}%"}
+        class={["nb-slider", @class || "w-full"]}
+        style={"--slider-progress: #{@slider_progress}%"}
         phx-hook=".RangeInput"
         {@rest}
       />
@@ -384,7 +384,7 @@ defmodule FlamingoWeb.CoreComponents do
             const max = Number(this.el.max || 100)
             const value = Number(this.el.value)
             const progress = max === min ? 0 : ((value - min) / (max - min)) * 100
-            this.el.style.setProperty("--range-progress", `${Math.min(100, Math.max(0, progress))}%`)
+            this.el.style.setProperty("--slider-progress", `${Math.min(100, Math.max(0, progress))}%`)
           }
 
           this.updateProgress()

--- a/lib/flamingo_web/components/layouts.ex
+++ b/lib/flamingo_web/components/layouts.ex
@@ -96,7 +96,7 @@ defmodule FlamingoWeb.Layouts do
             const visibleIcon = iconForVolume(clampedVolume);
 
             slider.value = clampedVolume;
-            slider.style.setProperty("--range-progress", `${clampedVolume}%`);
+            slider.style.setProperty("--slider-progress", `${clampedVolume}%`);
             window.__soundVolume = clampedVolume;
             window.__soundMuted = clampedVolume === 0;
             localStorage.setItem("flamingo_sound_volume", clampedVolume);

--- a/test/flamingo_web/live/home_live_test.exs
+++ b/test/flamingo_web/live/home_live_test.exs
@@ -134,7 +134,7 @@ defmodule FlamingoWeb.HomeLiveTest do
 
     assert document
            |> LazyHTML.query(
-             "#sound-volume-slider.range-input[type='range'][min='0'][max='100'][step='1'][value='100']"
+             "#sound-volume-slider.nb-slider[type='range'][min='0'][max='100'][step='1'][value='100'][style='--slider-progress: 100.0%']"
            )
            |> Enum.any?()
 

--- a/test/flamingo_web/live/scribble_live_test.exs
+++ b/test/flamingo_web/live/scribble_live_test.exs
@@ -106,7 +106,7 @@ defmodule FlamingoWeb.ScribbleLiveTest do
 
     assert has_element?(
              view,
-             "#round-count-slider.range-input[type='range'][min='1'][max='5'][value='3']"
+             "#round-count-slider.nb-slider[type='range'][min='1'][max='5'][value='3'][style='--slider-progress: 50.0%']"
            )
 
     assert has_element?(view, "#round-length-input[min='15'][max='120']")


### PR DESCRIPTION
The mix-and-match character creator replaced its slider controls with radio pickers, but that change also redesigned every shared range control. Round count and sound volume consequently moved away from the project's original compact neobrutalist styling even though their behavior was already correct.

This restores the exact pre-character-creator slider appearance while retaining the shared component's value-aware progress updates. The original character creator issue was localized to raw range inputs that never maintained the progress custom property; the current radio-based creator no longer has that failure mode.