### PR TITLE
Add telephone and constraint roulette game modes

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -215,6 +215,20 @@
   animation: starburst-pulse 2s ease-in-out infinite;
 }
 
+.roulette-hidden-canvas {
+  opacity: 0;
+}
+
+@keyframes roulette-canvas-rotate {
+  0%, 100% { transform: rotate(-5deg) scale(0.96); }
+  50% { transform: rotate(5deg) scale(0.96); }
+}
+
+.roulette-rotating-canvas {
+  animation: roulette-canvas-rotate 8s ease-in-out infinite;
+  transform-origin: center;
+}
+
 .range-input {
   -webkit-appearance: none;
   appearance: none;

--- a/assets/js/hooks/drawing_canvas.ts
+++ b/assets/js/hooks/drawing_canvas.ts
@@ -54,13 +54,17 @@ interface Point {
 }
 
 type ActiveTool = "pen" | "fill";
+type DrawingConstraint = "hidden_canvas" | "single_stroke" | "straight_lines" | "rotating_canvas" | "mirror" | "";
 
 interface DrawingCanvasHook {
   el: HTMLElement;
   canvas: HTMLCanvasElement;
   ctx: CanvasRenderingContext2D;
   isDrawer: boolean;
+  constraint: DrawingConstraint;
   isPainting: boolean;
+  strokeUsed: boolean;
+  straightStart: Point | null;
   lastCoord: Point | null;
   selectedColor: string;
   selectedThickness: number;
@@ -144,7 +148,7 @@ export const replayEvents = (
     }
   };
 
-  window.setTimeout(renderNext, delayMs);
+  renderNext();
 };
 
 const findUndoBoundaryIndex = (events: DrawEvent[]): number => {
@@ -156,9 +160,16 @@ const findUndoBoundaryIndex = (events: DrawEvent[]): number => {
   return -1;
 };
 
-const translatePointerToCanvas = (e: PointerEvent, canvas: HTMLCanvasElement): [number, number] => {
-  const rect = canvas.getBoundingClientRect();
-  return [e.clientX - rect.left, e.clientY - rect.top];
+const translatePointerToCanvas = (
+  e: PointerEvent,
+  canvas: HTMLCanvasElement,
+  constraint: DrawingConstraint
+): [number, number] => {
+  const scaleX = CANVAS_WIDTH / canvas.clientWidth;
+  const scaleY = CANVAS_HEIGHT / canvas.clientHeight;
+  const localX = Math.max(0, Math.min(CANVAS_WIDTH, e.offsetX * scaleX));
+  const localY = Math.max(0, Math.min(CANVAS_HEIGHT, e.offsetY * scaleY));
+  return [constraint === "mirror" ? CANVAS_WIDTH - localX : localX, localY];
 };
 
 const DrawingCanvas = {
@@ -166,7 +177,10 @@ const DrawingCanvas = {
     this.canvas = this.el.querySelector("canvas") as HTMLCanvasElement;
     this.ctx = this.canvas.getContext("2d", { willReadFrequently: true })!;
     this.isDrawer = this.el.dataset.isDrawer === "true";
+    this.constraint = (this.el.dataset.constraint ?? "") as DrawingConstraint;
     this.isPainting = false;
+    this.strokeUsed = false;
+    this.straightStart = null;
     this.lastCoord = null as Point | null;
     this.selectedColor = "#000000";
     this.selectedThickness = 9;
@@ -177,10 +191,22 @@ const DrawingCanvas = {
 
     canvasEffect(this.ctx, (imageData: ImageData) => clear(imageData));
 
+    if (this.isDrawer && this.constraint === "hidden_canvas") {
+      this.canvas.classList.add("roulette-hidden-canvas");
+    }
+
+    if (this.isDrawer && this.constraint === "rotating_canvas") {
+      this.canvas.classList.add("roulette-rotating-canvas");
+    }
+
     if (this.el.dataset.finalDrawingEvents) {
       const ops = JSON.parse(this.el.dataset.finalDrawingEvents) as CompactOp[];
       this.eventStack = opsToEvents(ops);
-      this.replayFinalDrawing();
+      renderEvents(this.ctx, this.eventStack);
+
+      if (this.el.dataset.finalDrawingReplay === "true") {
+        this.replayFinalDrawing();
+      }
     }
 
     if (this.isDrawer) {
@@ -243,7 +269,9 @@ const DrawingCanvas = {
 
     canvas.addEventListener("pointerdown", (e: PointerEvent) => {
       e.preventDefault();
-      const [x, y] = translatePointerToCanvas(e, canvas);
+      if (this.constraint === "single_stroke" && this.strokeUsed) return;
+
+      const [x, y] = translatePointerToCanvas(e, canvas, this.constraint);
 
       if (this.activeTool === "fill") {
         const fillEvent: DrawEvent = {
@@ -254,7 +282,10 @@ const DrawingCanvas = {
       }
 
       this.isPainting = true;
+      this.strokeUsed = true;
       this.lastCoord = { x, y };
+      this.straightStart = { x, y };
+      canvas.setPointerCapture(e.pointerId);
 
       const startEvent: DrawEvent = {
         event_type: "start", x, y,
@@ -267,7 +298,21 @@ const DrawingCanvas = {
       if (!this.isPainting) return;
       e.preventDefault();
 
-      const [x, y] = translatePointerToCanvas(e, canvas);
+      const [x, y] = translatePointerToCanvas(e, canvas, this.constraint);
+
+      if (this.constraint === "straight_lines") {
+        const start = this.straightStart ?? { x, y };
+        renderEvents(this.ctx, this.eventStack);
+        canvasEffect(this.ctx, (imageData: ImageData) => {
+          renderDrawEvent(imageData, {
+            event_type: "end",
+            start_x: start.x, start_y: start.y, end_x: x, end_y: y,
+            color: this.selectedColor, line_width: this.selectedThickness,
+          });
+        });
+        return;
+      }
+
       const prev: Point = this.lastCoord ?? { x, y };
       this.lastCoord = { x, y };
 
@@ -283,9 +328,12 @@ const DrawingCanvas = {
       if (!this.isPainting) return;
       this.isPainting = false;
 
-      const [x, y] = translatePointerToCanvas(e, canvas);
-      const prev: Point = this.lastCoord ?? { x, y };
+      const [x, y] = translatePointerToCanvas(e, canvas, this.constraint);
+      const prev: Point = this.constraint === "straight_lines"
+        ? (this.straightStart ?? { x, y })
+        : (this.lastCoord ?? { x, y });
       this.lastCoord = null;
+      this.straightStart = null;
 
       const endEvent: DrawEvent = {
         event_type: "end",
@@ -296,20 +344,7 @@ const DrawingCanvas = {
     };
 
     canvas.addEventListener("pointerup", handlePointerUp);
-    canvas.addEventListener("pointerleave", handlePointerUp);
-
-    canvas.addEventListener("pointerenter", (e: PointerEvent) => {
-      if (e.buttons === 1 && this.activeTool === "pen") {
-        const [x, y] = translatePointerToCanvas(e, canvas);
-        this.isPainting = true;
-        this.lastCoord = { x, y };
-        const startEvent: DrawEvent = {
-          event_type: "start", x, y,
-          color: this.selectedColor, line_width: this.selectedThickness,
-        };
-        pushDrawEvent(startEvent);
-      }
-    });
+    canvas.addEventListener("pointercancel", handlePointerUp);
   },
 
   performUndo(this: DrawingCanvasHook) {
@@ -373,6 +408,21 @@ const DrawingCanvas = {
     this.el.querySelector(`[data-color="#000000"]`)?.classList.add("ring-2", "ring-offset-1");
     this.el.querySelector(`[data-size="9"]`)?.classList.add("bg-pink-300");
     this.el.querySelector(`[data-tool="pen"]`)?.classList.add("bg-pink-300");
+
+    if (this.constraint === "single_stroke") {
+      this.el.querySelectorAll("[data-tool='fill'], [data-action]").forEach((button) => {
+        (button as HTMLButtonElement).disabled = true;
+        button.classList.add("cursor-not-allowed", "opacity-30");
+      });
+    }
+
+    if (this.constraint === "straight_lines") {
+      const fillButton = this.el.querySelector("[data-tool='fill']") as HTMLButtonElement | null;
+      if (fillButton) {
+        fillButton.disabled = true;
+        fillButton.classList.add("cursor-not-allowed", "opacity-30");
+      }
+    }
   },
 
   destroyed(this: DrawingCanvasHook) {

--- a/lib/flamingo/game_modes/scribble.ex
+++ b/lib/flamingo/game_modes/scribble.ex
@@ -8,6 +8,7 @@ defmodule Flamingo.GameModes.Scribble do
 
   @min_turn_length 15
   @max_turn_length 120
+  @constraints [:hidden_canvas, :single_stroke, :straight_lines, :rotating_canvas, :mirror]
 
   def new do
     %{
@@ -18,6 +19,8 @@ defmodule Flamingo.GameModes.Scribble do
       turn_length: 30,
       custom_words: [],
       include_default_words: false,
+      game_variant: :classic,
+      constraint: nil,
       drawer_id: nil,
       current_round: 0,
       drawn_this_round: MapSet.new(),
@@ -89,6 +92,7 @@ defmodule Flamingo.GameModes.Scribble do
     turn_length = Map.get(settings, :turn_length, state.turn_length)
     custom_words = Map.get(settings, :custom_words, state.custom_words)
     defaults = Map.get(settings, :include_default_words, state.include_default_words)
+    game_variant = Map.get(settings, :game_variant, state.game_variant)
     roster = context.roster
 
     with true <- context.actor_id == roster.host_id || {:error, :not_host},
@@ -97,7 +101,9 @@ defmodule Flamingo.GameModes.Scribble do
          true <-
            turn_length in @min_turn_length..@max_turn_length || {:error, :invalid_turn_length},
          {:ok, custom_words} <- Words.validate_custom_words(custom_words),
-         true <- is_boolean(defaults) || {:error, :invalid_include_default_words} do
+         true <- is_boolean(defaults) || {:error, :invalid_include_default_words},
+         true <-
+           game_variant in [:classic, :constraint_roulette] || {:error, :invalid_game_variant} do
       participants = Map.new(state.participants, fn {id, _} -> {id, :active} end)
 
       state = %{
@@ -106,6 +112,8 @@ defmodule Flamingo.GameModes.Scribble do
           turn_length: turn_length,
           custom_words: custom_words,
           include_default_words: defaults,
+          game_variant: game_variant,
+          constraint: nil,
           participants: participants,
           drawer_id: Enum.find(roster.player_order, &active?(participants, &1)),
           current_round: 0,
@@ -130,8 +138,9 @@ defmodule Flamingo.GameModes.Scribble do
     end
   end
 
-  def command(state, actor, {:draw, event}, _context) do
-    if state.phase == :playing and actor == state.drawer_id and active?(state, actor) do
+  def command(state, actor, {:draw, event}, _context) when is_map(event) do
+    if state.phase == :playing and actor == state.drawer_id and active?(state, actor) and
+         constraint_event_allowed?(state, event) do
       drawing =
         if event["event_type"] == "undo",
           do: undo(state.current_drawing),
@@ -144,6 +153,8 @@ defmodule Flamingo.GameModes.Scribble do
       :ignored
     end
   end
+
+  def command(_state, _actor, {:draw, _event}, _context), do: :ignored
 
   def command(state, actor, {:guess, text}, context) when is_binary(text) do
     cond do
@@ -189,6 +200,7 @@ defmodule Flamingo.GameModes.Scribble do
   end
 
   def command(_state, _actor, {:guess, _}, _context), do: {:error, :invalid_guess}
+  def command(_state, _actor, _command, _context), do: {:error, :invalid_command}
 
   def timeout(state, :word_choice, context) when state.phase == :word_choice do
     case choose(context, state.word_choices) do
@@ -243,6 +255,8 @@ defmodule Flamingo.GameModes.Scribble do
       custom_words: if(viewer == roster.host_id, do: state.custom_words, else: []),
       include_default_words:
         if(viewer == roster.host_id, do: state.include_default_words, else: false),
+      game_variant: state.game_variant,
+      constraint: state.constraint,
       word_choices:
         if(state.phase == :word_choice and viewer == state.drawer_id,
           do: state.word_choices,
@@ -269,6 +283,13 @@ defmodule Flamingo.GameModes.Scribble do
   defp enter_word_choice(state, context) do
     choices =
       context.word_choices.(3, state.used_words, state.custom_words, state.include_default_words)
+
+    constraint =
+      if state.game_variant == :constraint_roulette,
+        do: choose(context, @constraints),
+        else: nil
+
+    state = %{state | constraint: constraint}
 
     if choices == [],
       do: game_ended(state, context.roster),
@@ -447,6 +468,33 @@ defmodule Flamingo.GameModes.Scribble do
   defp online?(roster, id), do: roster.players[id].connected
   defp online_count(roster), do: Enum.count(roster.players, fn {_, p} -> p.connected end)
   defp choose(context, candidates), do: context.select_candidate.(candidates)
+
+  defp constraint_event_allowed?(%{constraint: :single_stroke} = state, event) do
+    type = event["event_type"]
+    stroke_started? = Enum.any?(state.current_drawing, &(&1["event_type"] == "start"))
+    stroke_ended? = Enum.any?(state.current_drawing, &(&1["event_type"] == "end"))
+
+    case type do
+      "start" -> not stroke_started?
+      type when type in ["draw", "end"] -> stroke_started? and not stroke_ended?
+      _ -> false
+    end
+  end
+
+  defp constraint_event_allowed?(%{constraint: :straight_lines} = state, event) do
+    open_line? =
+      Enum.count(state.current_drawing, &(&1["event_type"] == "start")) >
+        Enum.count(state.current_drawing, &(&1["event_type"] == "end"))
+
+    case event["event_type"] do
+      "start" -> not open_line?
+      "end" -> open_line?
+      type when type in ["undo", "clear"] -> true
+      _ -> false
+    end
+  end
+
+  defp constraint_event_allowed?(_state, _event), do: true
 
   defp transition(_old, {new, timers}, reply), do: ok(new, reply, timers)
 

--- a/lib/flamingo/game_modes/telephone.ex
+++ b/lib/flamingo/game_modes/telephone.ex
@@ -1,0 +1,582 @@
+defmodule Flamingo.GameModes.Telephone do
+  @moduledoc "Pure transitions for the Telephone drawing game."
+
+  alias Flamingo.{DrawingShare, Words}
+
+  @categories [:derailment, :best_save, :worst_drawing]
+
+  def new do
+    %{
+      phase: :lobby,
+      participants: %{},
+      turn_length: 30,
+      custom_words: [],
+      include_default_words: false,
+      players: %{},
+      player_order: [],
+      host_id: nil,
+      prompt_choices: %{},
+      selected_prompts: %{},
+      chains: [],
+      current_step: nil,
+      current_drawings: %{},
+      guesses: %{},
+      submitted: MapSet.new(),
+      reveal_chain_index: nil,
+      reveal_entry_index: nil,
+      votes: %{},
+      awards: %{},
+      final_result: nil
+    }
+  end
+
+  def admit_member(state, %{id: id}, context) do
+    participation = if state.phase == :lobby, do: :active, else: :spectator
+
+    ok(%{
+      state
+      | participants: Map.put(state.participants, id, participation),
+        host_id: state.host_id || context.roster.host_id
+    })
+  end
+
+  def connection_changed(state, _id, _connection, context), do: reconcile(state, context)
+
+  def remove_member(state, id, _removed, context) do
+    host_id = if state.host_id == id, do: context.roster.host_id, else: state.host_id
+
+    state = %{
+      state
+      | participants: Map.delete(state.participants, id),
+        host_id: host_id
+    }
+
+    reconcile(state, context)
+  end
+
+  def start(%{phase: phase}, _settings, _context) when phase not in [:lobby, :game_ended],
+    do: {:error, :game_in_progress}
+
+  def start(state, settings, context) do
+    roster = context.roster
+    turn_length = Map.get(settings, :turn_length, state.turn_length)
+    custom_words = Map.get(settings, :custom_words, state.custom_words)
+    defaults = Map.get(settings, :include_default_words, state.include_default_words)
+
+    order = Enum.filter(roster.player_order, &online?(roster, &1))
+
+    with true <- context.actor_id == roster.host_id || {:error, :not_host},
+         true <- length(order) >= 2 || {:error, :not_enough_players},
+         true <- turn_length in 15..120 || {:error, :invalid_turn_length},
+         {:ok, custom_words} <- Words.validate_custom_words(custom_words),
+         true <- is_boolean(defaults) || {:error, :invalid_include_default_words},
+         prompts when is_list(prompts) <-
+           context.word_choices.(max(length(order), 3), MapSet.new(), custom_words, defaults),
+         true <- length(prompts) >= length(order) || {:error, :not_enough_prompts} do
+      players =
+        Map.new(order, fn id ->
+          {id, roster.players[id] |> Map.take([:id, :name, :avatar])}
+        end)
+
+      prompt_choices =
+        order
+        |> Enum.with_index()
+        |> Map.new(fn {id, index} -> {id, rotated_choices(prompts, index)} end)
+
+      state = %{
+        state
+        | phase: :telephone_prompt,
+          participants: Map.new(roster.player_order, &{&1, participation(&1, order)}),
+          turn_length: turn_length,
+          custom_words: custom_words,
+          include_default_words: defaults,
+          players: players,
+          player_order: order,
+          host_id: roster.host_id,
+          prompt_choices: prompt_choices,
+          selected_prompts: %{},
+          chains: [],
+          current_step: nil,
+          current_drawings: %{},
+          guesses: %{},
+          submitted: MapSet.new(),
+          votes: %{},
+          awards: %{},
+          final_result: nil
+      }
+
+      ok(state, :ok, prompt_timers())
+    else
+      {:error, _} = error -> error
+      _ -> {:error, :invalid_prompts}
+    end
+  end
+
+  def command(state, actor, {:select_prompt, prompt}, context) when is_binary(prompt) do
+    choices = Map.get(state.prompt_choices, actor, [])
+
+    cond do
+      state.phase != :telephone_prompt ->
+        {:error, :not_prompt_choice}
+
+      not eligible?(state, actor) ->
+        {:error, :spectator}
+
+      MapSet.member?(state.submitted, actor) ->
+        {:error, :already_submitted}
+
+      prompt not in choices ->
+        {:error, :invalid_prompt}
+
+      true ->
+        state = %{
+          state
+          | selected_prompts: Map.put(state.selected_prompts, actor, prompt),
+            submitted: MapSet.put(state.submitted, actor)
+        }
+
+        reconcile(state, context)
+    end
+  end
+
+  def command(_state, _actor, {:select_prompt, _prompt}, _context),
+    do: {:error, :invalid_prompt}
+
+  def command(state, actor, {:draw, event}, _context) when is_map(event) do
+    if state.phase == :telephone_draw and eligible?(state, actor) and
+         not MapSet.member?(state.submitted, actor) and valid_draw_event?(event) do
+      old = Map.get(state.current_drawings, actor, [])
+      drawing = if event["event_type"] == "undo", do: undo(old), else: old ++ [event]
+
+      if drawing == old do
+        :ignored
+      else
+        state = %{state | current_drawings: Map.put(state.current_drawings, actor, drawing)}
+        ok(state, :ok, [], %{actor_id: actor, event: event}, :actor)
+      end
+    else
+      :ignored
+    end
+  end
+
+  def command(_state, _actor, {:draw, _event}, _context), do: {:error, :invalid_draw_event}
+
+  def command(state, actor, :submit_drawing, context) do
+    if state.phase == :telephone_draw and eligible?(state, actor) and
+         not MapSet.member?(state.submitted, actor) do
+      submit(state, actor, nil, context)
+    else
+      {:error, :cannot_submit}
+    end
+  end
+
+  def command(state, actor, {:submit_guess, text}, context) when is_binary(text) do
+    text = String.trim(text)
+
+    cond do
+      state.phase != :telephone_guess -> {:error, :not_guess_phase}
+      not eligible?(state, actor) -> {:error, :spectator}
+      MapSet.member?(state.submitted, actor) -> {:error, :already_submitted}
+      text == "" -> {:error, :invalid_guess}
+      String.length(text) > 100 -> {:error, :invalid_guess}
+      true -> submit(state, actor, text, context)
+    end
+  end
+
+  def command(_state, _actor, {:submit_guess, _}, _context), do: {:error, :invalid_guess}
+
+  def command(state, actor, :advance_reveal, _context) do
+    cond do
+      state.phase != :telephone_reveal -> {:error, :not_reveal}
+      actor != state.host_id -> {:error, :not_host}
+      final_reveal?(state) -> finish(state)
+      true -> ok(advance_reveal(state))
+    end
+  end
+
+  def command(state, actor, {:vote, category, entry_id}, _context) do
+    with true <- state.phase == :telephone_reveal || {:error, :not_reveal},
+         true <- eligible?(state, actor) || {:error, :spectator},
+         true <- category in @categories || {:error, :invalid_category},
+         {:ok, entry} <- revealed_entry(state, entry_id),
+         true <- not is_nil(entry.player_id) || {:error, :invalid_entry},
+         true <-
+           (category != :worst_drawing or entry.type == :drawing) ||
+             {:error, :invalid_entry} do
+      votes = Map.put(state.votes, {actor, category}, entry_id)
+      ok(%{state | votes: votes})
+    else
+      {:error, _} = error -> error
+    end
+  end
+
+  def command(_state, _actor, _command, _context), do: {:error, :invalid_command}
+
+  def timeout(state, :telephone_step, context)
+      when state.phase in [:telephone_draw, :telephone_guess],
+      do: transition(advance_step(state), context)
+
+  def timeout(%{phase: :telephone_prompt} = state, :telephone_prompt, context),
+    do: transition(enter_drawing(state), context)
+
+  def timeout(_state, _key, _context), do: :ignored
+
+  def view(state, viewer, roster) do
+    assignment = assignment(state, viewer)
+
+    assignment =
+      if assignment && state.phase == :telephone_draw do
+        Map.put(assignment, :current_drawing, Map.get(state.current_drawings, viewer, []))
+      else
+        assignment
+      end
+
+    %{
+      mode: :telephone,
+      phase: state.phase,
+      viewer_id: viewer,
+      participation: Map.get(state.participants, viewer),
+      players: state.players,
+      player_order: state.player_order,
+      host_id: state.host_id || roster.host_id,
+      turn_length: state.turn_length,
+      current_step: state.current_step,
+      step_count: length(state.player_order),
+      submitted_ids: state.submitted,
+      prompt_choices:
+        if(state.phase == :telephone_prompt and eligible?(state, viewer),
+          do: Map.get(state.prompt_choices, viewer, []),
+          else: []
+        ),
+      assignment: assignment,
+      reveal: reveal_projection(state),
+      votes: viewer_votes(state, viewer),
+      vote_counts: vote_counts(state),
+      awards: if(state.phase == :game_ended, do: state.awards, else: %{}),
+      custom_words:
+        if(viewer == (state.host_id || roster.host_id), do: state.custom_words, else: []),
+      include_default_words:
+        if(viewer == (state.host_id || roster.host_id),
+          do: state.include_default_words,
+          else: false
+        )
+    }
+  end
+
+  defp submit(state, actor, guess, context) do
+    state =
+      state
+      |> Map.update!(:submitted, &MapSet.put(&1, actor))
+      |> maybe_store_guess(actor, guess)
+
+    reconcile(state, context)
+  end
+
+  defp maybe_store_guess(state, _actor, nil), do: state
+
+  defp maybe_store_guess(state, actor, guess),
+    do: Map.put(state, :guesses, Map.put(Map.get(state, :guesses, %{}), actor, guess))
+
+  defp reconcile(%{phase: :telephone_prompt} = state, context) do
+    online = Enum.filter(state.player_order, &online?(context.roster, &1))
+
+    if online != [] and Enum.all?(online, &MapSet.member?(state.submitted, &1)),
+      do: transition(enter_drawing(state), context),
+      else: ok(state)
+  end
+
+  defp reconcile(state, context) when state.phase in [:telephone_draw, :telephone_guess] do
+    online = Enum.filter(state.player_order, &online?(context.roster, &1))
+
+    if online != [] and Enum.all?(online, &MapSet.member?(state.submitted, &1)),
+      do: transition(advance_step(state), context),
+      else: ok(state)
+  end
+
+  defp reconcile(state, _context), do: ok(state)
+
+  defp transition({state, timers}, _context), do: ok(state, :ok, timers)
+
+  defp enter_drawing(state) do
+    chains =
+      state.player_order
+      |> Enum.with_index()
+      |> Enum.map(fn {origin, index} ->
+        prompt =
+          Map.get(state.selected_prompts, origin) ||
+            state.prompt_choices |> Map.fetch!(origin) |> List.first()
+
+        %{
+          id: "telephone-chain-#{index}",
+          origin_player_id: origin,
+          entries: [entry(index, 0, :prompt, nil, prompt)]
+        }
+      end)
+
+    state = %{
+      state
+      | phase: :telephone_draw,
+        chains: chains,
+        current_step: 0,
+        current_drawings: Map.new(state.player_order, &{&1, []}),
+        guesses: %{},
+        submitted: MapSet.new()
+    }
+
+    {state, step_timers(state)}
+  end
+
+  defp advance_step(state) do
+    n = length(state.player_order)
+
+    chains =
+      Enum.with_index(state.player_order)
+      |> Enum.reduce(state.chains, fn {actor, actor_index}, chains ->
+        chain_index = Integer.mod(actor_index - state.current_step, n)
+        value = contribution(state, actor)
+        type = if state.phase == :telephone_draw, do: :drawing, else: :guess
+
+        update_in(
+          chains,
+          [Access.at(chain_index), :entries],
+          &(&1 ++ [entry(chain_index, state.current_step + 1, type, actor, value)])
+        )
+      end)
+
+    next = state.current_step + 1
+
+    if next >= n do
+      {%{
+         state
+         | phase: :telephone_reveal,
+           chains: chains,
+           current_step: nil,
+           submitted: MapSet.new(),
+           current_drawings: %{},
+           reveal_chain_index: 0,
+           reveal_entry_index: 0
+       }, [:cancel_phase_timeout, :cancel_hint_timeout]}
+    else
+      phase = if rem(next, 2) == 0, do: :telephone_draw, else: :telephone_guess
+
+      drawings =
+        if phase == :telephone_draw, do: Map.new(state.player_order, &{&1, []}), else: %{}
+
+      next_state = %{
+        state
+        | phase: phase,
+          chains: chains,
+          current_step: next,
+          submitted: MapSet.new(),
+          current_drawings: drawings,
+          guesses: %{}
+      }
+
+      {next_state, step_timers(next_state)}
+    end
+  end
+
+  defp contribution(%{phase: :telephone_draw} = state, actor) do
+    if MapSet.member?(state.submitted, actor),
+      do: DrawingShare.compact_ops(Map.get(state.current_drawings, actor, [])),
+      else: nil
+  end
+
+  defp contribution(state, actor),
+    do: if(MapSet.member?(state.submitted, actor), do: Map.get(state.guesses, actor), else: nil)
+
+  defp assignment(state, actor) when state.phase in [:telephone_draw, :telephone_guess] do
+    case Enum.find_index(state.player_order, &(&1 == actor)) do
+      nil ->
+        nil
+
+      index ->
+        chain =
+          Enum.at(
+            state.chains,
+            Integer.mod(index - state.current_step, length(state.player_order))
+          )
+
+        source = List.last(chain.entries)
+
+        %{
+          chain_id: chain.id,
+          type: if(state.phase == :telephone_draw, do: :drawing, else: :guess),
+          source: source
+        }
+    end
+  end
+
+  defp assignment(_state, _actor), do: nil
+
+  defp entry(chain, index, type, player, value),
+    do: %{
+      id: "telephone-chain-#{chain}-entry-#{index}",
+      type: type,
+      player_id: player,
+      value: value
+    }
+
+  defp eligible?(state, actor),
+    do: actor in state.player_order and Map.get(state.participants, actor) == :active
+
+  defp participation(id, order), do: if(id in order, do: :active, else: :spectator)
+
+  defp online?(roster, id), do: match?(%{connected: true}, roster.players[id])
+
+  defp step_timers(state),
+    do: [
+      :cancel_hint_timeout,
+      {:schedule_phase_timeout, :telephone_step, state.turn_length * 1000}
+    ]
+
+  defp prompt_timers,
+    do: [
+      :cancel_hint_timeout,
+      {:schedule_phase_timeout, :telephone_prompt, 15_000}
+    ]
+
+  defp rotated_choices(prompts, index) do
+    {before, after_index} = Enum.split(prompts, Integer.mod(index, length(prompts)))
+    Enum.take(after_index ++ before, 3)
+  end
+
+  defp advance_reveal(state) do
+    chain = Enum.at(state.chains, state.reveal_chain_index)
+
+    if state.reveal_entry_index + 1 < length(chain.entries),
+      do: %{state | reveal_entry_index: state.reveal_entry_index + 1},
+      else: %{state | reveal_chain_index: state.reveal_chain_index + 1, reveal_entry_index: 0}
+  end
+
+  defp final_reveal?(state),
+    do:
+      state.reveal_chain_index == length(state.chains) - 1 and
+        state.reveal_entry_index == length(List.last(state.chains).entries) - 1
+
+  defp reveal_projection(%{phase: phase} = state)
+       when phase in [:telephone_reveal, :game_ended] do
+    chain = Enum.at(state.chains, state.reveal_chain_index || length(state.chains) - 1)
+
+    %{
+      chain_index: state.reveal_chain_index,
+      entry_index: state.reveal_entry_index,
+      chain: %{
+        chain
+        | entries:
+            Enum.take(chain.entries, (state.reveal_entry_index || length(chain.entries) - 1) + 1)
+      }
+    }
+  end
+
+  defp reveal_projection(_state), do: nil
+
+  defp revealed_entry(state, id) do
+    entries =
+      state.chains
+      |> Enum.take(state.reveal_chain_index + 1)
+      |> Enum.with_index()
+      |> Enum.flat_map(fn {chain, i} ->
+        Enum.take(
+          chain.entries,
+          if(i == state.reveal_chain_index,
+            do: state.reveal_entry_index + 1,
+            else: length(chain.entries)
+          )
+        )
+      end)
+
+    case Enum.find(entries, &(&1.id == id)),
+      do: (
+        nil -> {:error, :entry_not_revealed}
+        entry -> {:ok, entry}
+      )
+  end
+
+  defp viewer_votes(state, viewer),
+    do: Map.new(@categories, &{&1, Map.get(state.votes, {viewer, &1})})
+
+  defp vote_counts(state),
+    do:
+      Enum.reduce(state.votes, %{}, fn {{_, category}, id}, acc ->
+        Map.update(acc, category, %{id => 1}, &Map.update(&1, id, 1, fn n -> n + 1 end))
+      end)
+
+  defp finish(state) do
+    awards = Map.new(@categories, &{&1, award(state, &1)})
+
+    result = %{
+      chains: state.chains,
+      players: state.players,
+      player_order: state.player_order,
+      votes: state.votes,
+      awards: awards
+    }
+
+    ok(%{state | phase: :game_ended, awards: awards, final_result: result}, :ok, [
+      :cancel_phase_timeout,
+      :cancel_hint_timeout
+    ])
+  end
+
+  defp award(state, category) do
+    counts = Map.get(vote_counts(state), category, %{})
+    ordered = Enum.flat_map(state.chains, & &1.entries)
+
+    case Enum.max_by(ordered, &Map.get(counts, &1.id, 0), fn -> nil end) do
+      nil ->
+        nil
+
+      entry ->
+        if Map.get(counts, entry.id, 0) == 0,
+          do: nil,
+          else: %{entry: entry, player_id: entry.player_id, votes: counts[entry.id]}
+    end
+  end
+
+  defp ok(state, reply \\ :ok, timers \\ [], delta \\ nil, scope \\ nil) do
+    status = if state.phase == :game_ended, do: {:finished, state.final_result}, else: :continue
+
+    {:ok,
+     %{
+       state: state,
+       reply: reply,
+       timers: timers,
+       status: status,
+       drawing_delta: delta,
+       drawing_scope: scope
+     }}
+  end
+
+  defp undo(events) do
+    idx =
+      events
+      |> Enum.reverse()
+      |> Enum.find_index(&(&1["event_type"] in ["start", "fill", "clear"]))
+
+    if idx, do: Enum.take(events, length(events) - idx - 1), else: events
+  end
+
+  defp valid_draw_event?(%{"event_type" => type}) when type in ["clear", "undo"], do: true
+
+  defp valid_draw_event?(%{"event_type" => "start"} = event),
+    do:
+      valid_number?(event["x"]) and valid_number?(event["y"]) and
+        valid_pen?(event["color"], event["line_width"])
+
+  defp valid_draw_event?(%{"event_type" => type} = event) when type in ["draw", "end"],
+    do:
+      Enum.all?(~w(start_x start_y end_x end_y), &valid_number?(event[&1])) and
+        valid_pen?(event["color"], event["line_width"])
+
+  defp valid_draw_event?(%{"event_type" => "fill"} = event),
+    do: valid_number?(event["x"]) and valid_number?(event["y"]) and valid_color?(event["color"])
+
+  defp valid_draw_event?(_event), do: false
+  defp valid_number?(value), do: is_number(value) and value >= -100 and value <= 1_000
+
+  defp valid_pen?(color, width),
+    do: valid_color?(color) and is_number(width) and width > 0 and width <= 50
+
+  defp valid_color?(color), do: is_binary(color) and color =~ ~r/^#[0-9A-Fa-f]{6}$/
+end

--- a/lib/flamingo/room/members.ex
+++ b/lib/flamingo/room/members.ex
@@ -40,9 +40,12 @@ defmodule Flamingo.Room.Members do
         order = List.delete(members.order, seat_id)
 
         host_id =
-          if members.host_id == seat_id,
-            do: List.first(order),
-            else: members.host_id
+          if members.host_id == seat_id do
+            Enum.find(order, fn id -> members.seats[id].connection_count > 0 end) ||
+              List.first(order)
+          else
+            members.host_id
+          end
 
         resume_tokens =
           Map.reject(members.resume_tokens, fn {_resume_token, id} -> id == seat_id end)

--- a/lib/flamingo/room_server.ex
+++ b/lib/flamingo/room_server.ex
@@ -1,7 +1,7 @@
 defmodule Flamingo.RoomServer do
   use GenServer
 
-  alias Flamingo.GameModes.Scribble
+  alias Flamingo.GameModes.{Scribble, Telephone}
   alias Flamingo.Room.Members
 
   @disconnect_grace_ms 60_000
@@ -11,6 +11,7 @@ defmodule Flamingo.RoomServer do
     :phase_timer,
     :hint_timer,
     :turn_end_time,
+    game_module: Scribble,
     lifecycle: :lobby,
     members: Members.new(),
     game: Scribble.new(),
@@ -26,6 +27,7 @@ defmodule Flamingo.RoomServer do
   def select_word(id, word), do: GenServer.call(via(id), {:select_word, self(), word})
   def draw_event(id, event), do: GenServer.cast(via(id), {:draw_event, self(), event})
   def guess(id, text), do: GenServer.call(via(id), {:guess, self(), text})
+  def command(id, command), do: GenServer.call(via(id), {:command, self(), command})
   def snapshot(id), do: call(id, {:snapshot, self()}, {:error, :not_found})
 
   defp call(id, message, fallback) do
@@ -46,7 +48,7 @@ defmodule Flamingo.RoomServer do
     with {:ok, members} <- Members.add(state.members, id, token, name, avatar),
          context = context(state, members),
          {:ok, result} <-
-           Scribble.admit_member(state.game, %{id: id, name: name}, context) do
+           state.game_module.admit_member(state.game, %{id: id, name: name}, context) do
       state =
         %{state | members: members} |> accept(result, context.now) |> commit()
 
@@ -87,6 +89,9 @@ defmodule Flamingo.RoomServer do
   def handle_call({:guess, pid, text}, _, state),
     do: command_call(state, player_id(state, pid), {:guess, text})
 
+  def handle_call({:command, pid, command}, _, state),
+    do: command_call(state, player_id(state, pid), command)
+
   def handle_call({:leave, pid}, _, state) do
     case player_id(state, pid) do
       nil -> {:reply, :ok, state}
@@ -98,10 +103,16 @@ defmodule Flamingo.RoomServer do
   def handle_cast({:draw_event, pid, event}, state) do
     context = context(state)
 
-    case Scribble.command(state.game, player_id(state, pid), {:draw, event}, context) do
+    actor = player_id(state, pid)
+
+    case state.game_module.command(state.game, actor, {:draw, event}, context) do
       {:ok, result} ->
-        Enum.each(state.connections, fn {other, _} ->
-          if other != pid, do: send(other, {:draw_event, result.drawing_delta})
+        Enum.each(state.connections, fn {other, connection} ->
+          deliver? =
+            other != pid and
+              (Map.get(result, :drawing_scope) != :actor or connection.player_id == actor)
+
+          if deliver?, do: send(other, {:draw_event, result.drawing_delta})
         end)
 
         {:noreply, %{state | game: result.state}}
@@ -155,14 +166,23 @@ defmodule Flamingo.RoomServer do
 
   defp command_call(state, id, command) do
     context = context(state)
-    run_call(state, Scribble.command(state.game, id, command, context), context.now)
+    run_call(state, state.game_module.command(state.game, id, command, context), context.now)
   end
 
   defp start_game_call(state, nil, _settings), do: {:reply, {:error, :not_found}, state}
 
   defp start_game_call(state, actor, settings) do
     context = context(state, state.members, actor)
-    run_call(state, Scribble.start(state.game, settings, context), context.now)
+
+    with {:ok, module} <- mode_module(Map.get(settings, :game_mode, :scribble)),
+         :ok <- allow_mode_switch(state, module),
+         {:ok, game} <- game_for_start(state, module, context),
+         {:ok, result} <- module.start(game, settings, context) do
+      state = %{state | game_module: module}
+      run_call(state, {:ok, result}, context.now)
+    else
+      {:error, reason} -> {:reply, {:error, reason}, state}
+    end
   end
 
   defp run_call(state, {:error, reason}, _now), do: {:reply, {:error, reason}, state}
@@ -178,7 +198,7 @@ defmodule Flamingo.RoomServer do
     context = context(state)
 
     state =
-      case Scribble.timeout(state.game, key, context) do
+      case state.game_module.timeout(state.game, key, context) do
         {:ok, result} -> accept(state, result, context.now)
         _ -> state
       end
@@ -216,7 +236,7 @@ defmodule Flamingo.RoomServer do
 
   defp connection_transition(state, id, status) do
     context = context(state)
-    {:ok, result} = Scribble.connection_changed(state.game, id, status, context)
+    {:ok, result} = state.game_module.connection_changed(state.game, id, status, context)
     accept(state, result, context.now)
   end
 
@@ -237,7 +257,9 @@ defmodule Flamingo.RoomServer do
     }
 
     context = context(state)
-    {:ok, result} = Scribble.remove_member(state.game, id, %{id: id, name: seat.name}, context)
+
+    {:ok, result} =
+      state.game_module.remove_member(state.game, id, %{id: id, name: seat.name}, context)
 
     accept(state, result, context.now)
   end
@@ -312,8 +334,32 @@ defmodule Flamingo.RoomServer do
 
   defp snapshot_for(state, id),
     do:
-      Scribble.view(state.game, id, Members.snapshot(state.members))
+      state.game_module.view(state.game, id, Members.snapshot(state.members))
       |> Map.put(:turn_end_time, state.turn_end_time)
+
+  defp mode_module(:telephone), do: {:ok, Telephone}
+  defp mode_module(:scribble), do: {:ok, Scribble}
+  defp mode_module(_mode), do: {:error, :invalid_game_mode}
+
+  defp allow_mode_switch(%{lifecycle: :playing, game_module: current}, requested)
+       when current != requested,
+       do: {:error, :game_in_progress}
+
+  defp allow_mode_switch(_state, _requested), do: :ok
+
+  defp game_for_start(%{game_module: module, game: game}, module, _context), do: {:ok, game}
+
+  defp game_for_start(_state, module, context) do
+    context.roster.player_order
+    |> Enum.reduce_while({:ok, module.new()}, fn id, {:ok, game} ->
+      player = context.roster.players[id]
+
+      case module.admit_member(game, player, context) do
+        {:ok, result} -> {:cont, {:ok, result.state}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
 
   defp commit(state, excluded \\ nil) do
     state.connections

--- a/lib/flamingo/rooms.ex
+++ b/lib/flamingo/rooms.ex
@@ -34,4 +34,8 @@ defmodule Flamingo.Rooms do
   def guess(room_id, text) do
     RoomServer.guess(room_id, text)
   end
+
+  def command(room_id, command) do
+    RoomServer.command(room_id, command)
+  end
 end

--- a/lib/flamingo_web/components/telephone_components.ex
+++ b/lib/flamingo_web/components/telephone_components.ex
@@ -1,0 +1,448 @@
+defmodule FlamingoWeb.TelephoneComponents do
+  use FlamingoWeb, :html
+
+  @palette ~w(#000000 #FFFFFF #C1C1C1 #505050 #EF120B #740A08 #FF7700 #C23900 #FFE404 #E8A202 #08C202 #00461A #00FF91 #04785E #00B2FF #02569E #2220D3 #0E0865 #A302BA #550069 #DF69A7 #883454 #FFAC8A #CC7C4D #A0522D #63300D)
+  @categories [
+    {:derailment, "Biggest derailment", :shuffle},
+    {:best_save, "Best save", :life_buoy},
+    {:worst_drawing, "Wildest drawing", :paintbrush}
+  ]
+
+  attr :choices, :list, required: true
+  attr :submitted, :boolean, required: true
+
+  def prompt_phase(assigns) do
+    ~H"""
+    <section id="telephone-prompt-phase" class="mx-auto w-full max-w-4xl py-8 sm:py-16">
+      <.box class="bg-white p-6 text-center sm:p-10">
+        <p class="text-sm font-bold tracking-widest text-purple-600 uppercase">Start your chain</p>
+        <h2 class="mt-2 text-3xl font-black sm:text-5xl">Choose what you’ll draw</h2>
+        <p class="mx-auto mt-3 max-w-xl text-gray-600">
+          Everyone picks privately. Your prompt starts a chain that will travel around the room.
+        </p>
+        <%= if @submitted do %>
+          <div
+            id="prompt-submitted-waiting"
+            class="mt-8 rounded-base border-2 border-green-700 bg-green-100 p-6 font-bold"
+          >
+            <.icon name={:check_circle} class="mr-2 inline h-6 w-6" />Prompt locked in—waiting for everyone else.
+          </div>
+        <% else %>
+          <div id="telephone-prompt-choices" class="mt-8 grid gap-3 sm:grid-cols-3">
+            <.button
+              :for={prompt <- @choices}
+              id={"telephone-prompt-#{prompt_id(prompt)}"}
+              phx-click="select_prompt"
+              phx-value-prompt={prompt}
+              class="min-h-20 justify-center px-5 py-4 text-lg font-black"
+            >
+              {prompt}
+            </.button>
+          </div>
+        <% end %>
+      </.box>
+    </section>
+    """
+  end
+
+  attr :assignment, :map, default: nil
+  attr :submitted, :boolean, required: true
+
+  def draw_phase(assigns) do
+    assigns = assign(assigns, :palette, @palette)
+
+    ~H"""
+    <section id="telephone-draw-phase" class="grid items-start gap-4 lg:grid-cols-[1fr_18rem]">
+      <div class="relative min-w-0">
+        <.box class="mb-3 bg-white p-3 text-center">
+          <p class="text-xs font-bold tracking-wider text-gray-500 uppercase">Your link says</p>
+          <p id="draw-source-text" class="text-xl font-black sm:text-2xl">
+            {source_text(@assignment)}
+          </p>
+        </.box>
+        <div
+          id="telephone-drawing-canvas"
+          phx-hook="DrawingCanvas"
+          phx-update="ignore"
+          data-is-drawer="true"
+          class="flex flex-col gap-3"
+        >
+          <.box class="overflow-hidden bg-white p-0">
+            <canvas width="700" height="500" class="aspect-[7/5] w-full cursor-crosshair bg-white">
+            </canvas>
+          </.box>
+          <.box class="overflow-x-auto bg-white p-0"><.drawing_toolbar palette={@palette} /></.box>
+        </div>
+        <div
+          :if={@submitted}
+          id="drawing-submitted-overlay"
+          class="absolute inset-0 z-20 flex items-center justify-center rounded-base bg-white/85 p-6 text-center backdrop-blur-sm"
+        >
+          <div>
+            <.icon name={:check_circle} class="mx-auto h-12 w-12 text-green-600" />
+            <p class="mt-2 text-2xl font-black">Drawing delivered!</p>
+            <p>Waiting for the other artists…</p>
+          </div>
+        </div>
+      </div>
+      <.box class="bg-pink-100 p-5 text-center lg:sticky lg:top-5">
+        <.icon name={:pencil_line} class="mx-auto h-10 w-10" />
+        <h2 class="mt-2 text-xl font-black">Pass the picture on</h2>
+        <p class="my-4 text-sm text-gray-700">Make it recognizable—or wonderfully confusing.</p>
+        <.button
+          id="submit-telephone-drawing"
+          phx-click="submit_drawing"
+          disabled={@submitted}
+          class="w-full justify-center px-6 py-3 text-lg font-black"
+        >
+          Done drawing
+        </.button>
+      </.box>
+    </section>
+    """
+  end
+
+  attr :assignment, :map, default: nil
+  attr :submitted, :boolean, required: true
+  attr :form, :map, required: true
+
+  def guess_phase(assigns) do
+    ~H"""
+    <section id="telephone-guess-phase" class="mx-auto w-full max-w-4xl">
+      <.box class="bg-white p-4 sm:p-6">
+        <div class="mb-4 text-center">
+          <p class="text-xs font-bold tracking-wider text-gray-500 uppercase">
+            What is this supposed to be?
+          </p>
+          <h2 class="text-2xl font-black">Write the next link</h2>
+        </div>
+        <div
+          id="telephone-guess-drawing"
+          phx-hook="DrawingCanvas"
+          phx-update="ignore"
+          data-is-drawer="false"
+          data-final-drawing-replay="false"
+          data-final-drawing-events={drawing_json(@assignment)}
+        >
+          <div class="relative mx-auto aspect-[7/5] w-full max-w-[700px] bg-white">
+            <canvas width="700" height="500" class="absolute inset-0 h-full w-full"></canvas>
+            <.drawing_fallback ops={drawing_ops(@assignment)} />
+          </div>
+        </div>
+        <%= if @submitted do %>
+          <div
+            id="guess-submitted-waiting"
+            class="mt-5 rounded-base border-2 border-green-700 bg-green-100 p-5 text-center font-bold"
+          >
+            <.icon name={:check_circle} class="mr-2 inline h-6 w-6" />Guess delivered—waiting for everyone else.
+          </div>
+        <% else %>
+          <.form
+            for={@form}
+            id="telephone-guess-form"
+            phx-submit="submit_guess"
+            class="mx-auto mt-5 flex max-w-2xl flex-col gap-2 sm:flex-row"
+          >
+            <div class="min-w-0 flex-1">
+              <.input
+                field={@form[:text]}
+                id="telephone-guess-input"
+                type="text"
+                maxlength="100"
+                autocomplete="off"
+                placeholder="It looks like…"
+                class="w-full rounded-base border-2 border-border bg-white px-4 py-3 text-base focus:ring-2 focus:ring-ring focus:outline-none"
+              />
+            </div>
+            <.button
+              id="telephone-guess-submit"
+              type="submit"
+              class="justify-center px-6 py-3 font-black"
+            >
+              Send guess
+            </.button>
+          </.form>
+        <% end %>
+      </.box>
+    </section>
+    """
+  end
+
+  attr :reveal, :map, default: nil
+  attr :players, :map, required: true
+  attr :viewer_id, :any, required: true
+  attr :host_id, :any, required: true
+  attr :participation, :atom, required: true
+  attr :votes, :map, required: true
+  attr :vote_counts, :map, required: true
+
+  def reveal_phase(assigns) do
+    chain = assigns.reveal && Map.get(assigns.reveal, :chain)
+    entries = if chain, do: Map.get(chain, :entries, []), else: []
+    assigns = assign(assigns, chain: chain, entries: entries, categories: @categories)
+
+    ~H"""
+    <section id="telephone-reveal-phase" class="space-y-5">
+      <.box class="bg-purple-100 p-5 text-center">
+        <p id="reveal-progress" class="text-sm font-bold tracking-wider uppercase">
+          Chain {number(@reveal, :chain_index)} · Link {number(@reveal, :entry_index)}
+        </p>
+        <h2 class="font-hero text-3xl font-black text-purple-700 sm:text-5xl">The grand reveal</h2>
+        <p class="mt-2">
+          Started by <strong>{player_name(@players, @chain && @chain.origin_player_id)}</strong>
+        </p>
+      </.box>
+      <div
+        id="revealed-entries"
+        class={[
+          "grid gap-5",
+          length(@entries) == 1 && "mx-auto w-full max-w-2xl",
+          length(@entries) > 1 && "md:grid-cols-2"
+        ]}
+      >
+        <article
+          :for={entry <- @entries}
+          id={"telephone-entry-#{entry.id}"}
+          class="animate-in fade-in zoom-in-95 duration-500 rounded-base border-2 border-border bg-white p-4 shadow-shadow transition hover:-translate-y-1"
+        >
+          <div class="mb-3 flex items-center gap-2">
+            <.flamingo_avatar
+              avatar={player_avatar(@players, entry.player_id || @chain.origin_player_id)}
+              class="h-10 w-10"
+              label={
+                "#{player_name(@players, entry.player_id || @chain.origin_player_id)}'s avatar"
+              }
+            />
+            <div>
+              <p class="font-bold">
+                {player_name(@players, entry.player_id || @chain.origin_player_id)}
+              </p>
+              <p class="text-xs font-bold text-gray-500 uppercase">{entry_label(entry)}</p>
+            </div>
+          </div>
+          <%= if entry.type == :drawing do %>
+            <div
+              id={"reveal-drawing-#{entry.id}"}
+              phx-hook="DrawingCanvas"
+              phx-update="ignore"
+              data-is-drawer="false"
+              data-final-drawing-replay="true"
+              data-final-drawing-events={Jason.encode!(entry.value || [])}
+            >
+              <div class="relative aspect-[7/5] w-full bg-white">
+                <canvas width="700" height="500" class="absolute inset-0 h-full w-full"></canvas>
+                <.drawing_fallback ops={entry.value || []} />
+              </div>
+            </div>
+          <% else %>
+            <p
+              id={"reveal-text-#{entry.id}"}
+              class="flex min-h-36 items-center justify-center p-5 text-center font-hero text-3xl font-black text-pink-500"
+            >
+              {present_text(entry.value)}
+            </p>
+          <% end %>
+          <div :if={@participation == :active} class="mt-4 flex flex-wrap gap-2">
+            <button
+              :for={{category, label, icon} <- applicable_categories(@categories, entry)}
+              id={"vote-#{category}-#{entry.id}"}
+              phx-click="vote"
+              phx-value-category={category}
+              phx-value-entry-id={entry.id}
+              class={[
+                "flex items-center gap-1 rounded-full border-2 border-border px-3 py-1.5 text-xs font-bold transition hover:bg-yellow-100",
+                Map.get(@votes, category) == entry.id && "bg-yellow-200 shadow-shadow"
+              ]}
+            >
+              <.icon name={icon} class="h-4 w-4" />{label}<span class="rounded-full bg-white px-1.5">{vote_count(@vote_counts, category, entry.id)}</span>
+            </button>
+          </div>
+        </article>
+      </div>
+      <div id="reveal-controls" class="text-center">
+        <.button
+          :if={@viewer_id == @host_id}
+          id="advance-telephone-reveal"
+          phx-click="advance_reveal"
+          class="px-8 py-3 text-lg font-black"
+        >
+          Next reveal <.icon name={:arrow_right} class="ml-2 h-5 w-5" />
+        </.button>
+        <p :if={@viewer_id != @host_id} id="waiting-for-reveal-host" class="font-bold text-gray-600">
+          The host is choosing the dramatic moment…
+        </p>
+      </div>
+    </section>
+    """
+  end
+
+  attr :awards, :map, required: true
+  attr :players, :map, required: true
+  attr :host?, :boolean, required: true
+
+  def awards_phase(assigns) do
+    assigns = assign(assigns, categories: @categories)
+
+    ~H"""
+    <section id="telephone-awards" class="space-y-6 text-center">
+      <div>
+        <p class="font-hero text-lg font-black text-purple-600">FIN</p>
+        <h2 class="text-4xl font-black sm:text-6xl">Telephone legends</h2>
+      </div>
+      <div class="grid gap-4 md:grid-cols-3">
+        <.box
+          :for={{category, label, icon} <- @categories}
+          class="bg-white p-6 transition hover:-translate-y-1"
+        >
+          <.icon name={icon} class="mx-auto h-9 w-9 text-pink-500" />
+          <h3 class="mt-2 text-xl font-black">{label}</h3>
+          <%= if award = Map.get(@awards, category) do %>
+            <.flamingo_avatar
+              avatar={player_avatar(@players, award.player_id)}
+              class="mx-auto mt-4 h-24 w-24"
+              label={"#{player_name(@players, award.player_id)}'s avatar"}
+            />
+            <p class="text-2xl font-black">{player_name(@players, award.player_id)}</p>
+            <p class="text-sm text-gray-600">
+              {award.votes} {if(award.votes == 1, do: "vote", else: "votes")}
+            </p>
+          <% else %>
+            <p class="mt-8 text-gray-500">No votes this time—every link is a winner.</p>
+          <% end %>
+        </.box>
+      </div>
+      <div class="flex flex-wrap justify-center gap-3">
+        <.button
+          :if={@host?}
+          id="telephone-play-again"
+          phx-click="play_again"
+          class="px-7 py-3 font-black"
+        >
+          <.icon name={:rotate_cw} class="mr-2 h-5 w-5" />Play again
+        </.button>
+        <.button
+          id="telephone-new-room"
+          navigate={~p"/"}
+          variant="neutral"
+          class="px-7 py-3 font-black"
+        >
+          New room
+        </.button>
+      </div>
+    </section>
+    """
+  end
+
+  attr :ops, :list, required: true
+
+  def drawing_fallback(assigns) do
+    assigns = assign(assigns, :marks, svg_marks(assigns.ops))
+
+    ~H"""
+    <svg
+      :if={@marks != []}
+      class="pointer-events-none absolute inset-0 z-10 h-full w-full"
+      viewBox="0 0 700 500"
+      preserveAspectRatio="none"
+      aria-hidden="true"
+    >
+      <%= for mark <- @marks do %>
+        <polyline
+          :if={mark.type == :stroke}
+          points={mark.points}
+          fill="none"
+          stroke={mark.color}
+          stroke-width={mark.width}
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+        <circle
+          :if={mark.type == :dot}
+          cx={mark.x}
+          cy={mark.y}
+          r={mark.width / 2}
+          fill={mark.color}
+        />
+      <% end %>
+    </svg>
+    """
+  end
+
+  defp source_text(nil), do: "No prompt was provided"
+  defp source_text(%{source: source}), do: present_text(source && source.value)
+  defp source_text(_), do: "No prompt was provided"
+  defp drawing_json(%{source: %{value: value}}), do: Jason.encode!(value || [])
+  defp drawing_json(_), do: "[]"
+  defp drawing_ops(%{source: %{value: value}}) when is_list(value), do: value
+  defp drawing_ops(_), do: []
+
+  defp svg_marks(ops) do
+    Enum.reduce(ops, [], fn
+      ["c"], _marks ->
+        []
+
+      ["p", color, width, coordinates], marks
+      when is_binary(color) and is_number(width) and is_list(coordinates) ->
+        case svg_points(coordinates) do
+          [{x, y}] ->
+            marks ++ [%{type: :dot, x: x, y: y, color: color, width: width}]
+
+          points when points != [] ->
+            encoded = Enum.map_join(points, " ", fn {x, y} -> "#{x},#{y}" end)
+            marks ++ [%{type: :stroke, points: encoded, color: color, width: width}]
+
+          [] ->
+            marks
+        end
+
+      _op, marks ->
+        marks
+    end)
+  end
+
+  defp svg_points([x, y | deltas]) when is_number(x) and is_number(y) do
+    {points, _last} =
+      deltas
+      |> Enum.chunk_every(2)
+      |> Enum.map_reduce({x, y}, fn
+        [dx, dy], {previous_x, previous_y} when is_number(dx) and is_number(dy) ->
+          point = {previous_x + dx, previous_y + dy}
+          {point, point}
+
+        _invalid, previous ->
+          {previous, previous}
+      end)
+
+    [{x, y} | points]
+  end
+
+  defp svg_points(_coordinates), do: []
+
+  defp present_text(value) when is_binary(value),
+    do: if(String.trim(value) == "", do: "A mysterious blank link", else: value)
+
+  defp present_text(_), do: "A mysterious blank link"
+  defp number(nil, _key), do: "–"
+
+  defp number(map, key),
+    do: if(is_integer(Map.get(map, key)), do: Map.get(map, key) + 1, else: "–")
+
+  defp entry_label(%{type: :prompt}), do: "Original prompt"
+  defp entry_label(%{type: :drawing}), do: "Drawing"
+  defp entry_label(%{type: :guess}), do: "Guess"
+  defp entry_label(_), do: "Missing link"
+  defp applicable_categories(categories, %{type: :drawing}), do: categories
+  defp applicable_categories(_categories, %{type: :prompt}), do: []
+
+  defp applicable_categories(categories, _entry),
+    do: Enum.reject(categories, &(elem(&1, 0) == :worst_drawing))
+
+  defp vote_count(counts, category, entry_id),
+    do: counts |> Map.get(category, %{}) |> Map.get(entry_id, 0)
+
+  defp player(players, id), do: Map.get(players, id, %{})
+  defp player_name(_players, nil), do: "an unknown player"
+  defp player_name(players, id), do: Map.get(player(players, id), :name, "Unknown player")
+  defp player_avatar(players, id), do: Map.get(player(players, id), :avatar, %{})
+  defp prompt_id(prompt), do: Base.url_encode64(prompt, padding: false)
+end

--- a/lib/flamingo_web/live/scribble_live.ex
+++ b/lib/flamingo_web/live/scribble_live.ex
@@ -19,6 +19,7 @@ defmodule FlamingoWeb.ScribbleLive do
      socket
      |> assign(
        room_id: room_id,
+       resume_token: nil,
        player_id: nil,
        participation: :active,
        phase: :lobby,
@@ -30,8 +31,11 @@ defmodule FlamingoWeb.ScribbleLive do
        selected_player_id: nil,
        host_id: nil,
        drawer_id: nil,
+       constraint: nil,
        round_count: 3,
        turn_length: 45,
+       game_mode: :scribble,
+       game_variant: :classic,
        custom_words: "",
        custom_word_count: 0,
        custom_words_error: nil,
@@ -40,6 +44,7 @@ defmodule FlamingoWeb.ScribbleLive do
            %{
              "round_count" => "3",
              "turn_length" => "45",
+             "game_mode" => "classic",
              "custom_words" => "",
              "include_default_words" => false
            },
@@ -65,9 +70,16 @@ defmodule FlamingoWeb.ScribbleLive do
 
     if connected?(socket) do
       case Rooms.connect(room_id, resume_token) do
+        {:ok, %{mode: :telephone}} ->
+          {:noreply,
+           push_navigate(socket,
+             to: ~p"/game/#{room_id}/telephone?resume_token=#{resume_token}"
+           )}
+
         {:ok, snapshot} ->
           socket =
             socket
+            |> assign(:resume_token, resume_token)
             |> apply_snapshot(snapshot)
 
           {:noreply, push_event(socket, "play_sound", %{sound: "join"})}
@@ -76,7 +88,7 @@ defmodule FlamingoWeb.ScribbleLive do
           {:noreply, push_navigate(socket, to: ~p"/")}
       end
     else
-      {:noreply, socket}
+      {:noreply, assign(socket, :resume_token, resume_token)}
     end
   end
 
@@ -85,6 +97,17 @@ defmodule FlamingoWeb.ScribbleLive do
   end
 
   defp palette, do: @palette
+
+  defp constraint_label(:hidden_canvas), do: "Draw blind — your canvas is hidden"
+  defp constraint_label(:single_stroke), do: "One stroke — don't lift your pen"
+  defp constraint_label(:straight_lines), do: "Straight lines only"
+  defp constraint_label(:rotating_canvas), do: "Moving target — the canvas is rotating"
+  defp constraint_label(:mirror), do: "Mirror mode — horizontal movement is reversed"
+  defp constraint_label(_constraint), do: nil
+
+  defp selected_game_mode(:telephone, _variant), do: "telephone"
+  defp selected_game_mode(:scribble, :constraint_roulette), do: "constraint_roulette"
+  defp selected_game_mode(_mode, _variant), do: "classic"
 
   defp winning_player_id(players, player_order) do
     Enum.max_by(player_order, fn pid -> Map.get(players, pid).score end, fn -> nil end)
@@ -163,6 +186,38 @@ defmodule FlamingoWeb.ScribbleLive do
                   class="min-h-0 flex-1 overflow-y-auto p-4"
                   id="settings-form"
                 >
+                  <fieldset class="mb-4">
+                    <legend class="text-sm">Game mode</legend>
+                    <div class="mt-1 grid grid-cols-1 gap-2 sm:grid-cols-3">
+                      <label
+                        :for={
+                          {value, title, description} <- [
+                            {"classic", "Classic", "The original draw-and-guess game"},
+                            {"constraint_roulette", "Constraint roulette",
+                             "A surprise drawing rule every turn"},
+                            {"telephone", "Telephone",
+                             "Everyone draws, guesses, then reveals the chaos"}
+                          ]
+                        }
+                        class={[
+                          "cursor-pointer border-2 border-border p-3 transition-all hover:-translate-y-0.5 hover:shadow-shadow",
+                          selected_game_mode(@game_mode, @game_variant) == value &&
+                            "bg-pink-100 shadow-shadow"
+                        ]}
+                      >
+                        <input
+                          type="radio"
+                          name={@settings_form[:game_mode].name}
+                          value={value}
+                          checked={selected_game_mode(@game_mode, @game_variant) == value}
+                          class="sr-only"
+                        />
+                        <span class="block font-bold">{title}</span>
+                        <span class="block text-xs text-gray-600">{description}</span>
+                      </label>
+                    </div>
+                  </fieldset>
+
                   <div class="space-y-1">
                     <div class="flex w-full justify-between">
                       <label for="round-count-slider" class="text-sm">Rounds</label>
@@ -348,6 +403,15 @@ defmodule FlamingoWeb.ScribbleLive do
                   </.box>
                 <% true -> %>
                   <div class="relative flex w-[704px] shrink-0 flex-col gap-4">
+                    <div
+                      :if={@constraint}
+                      id="constraint-banner"
+                      class="absolute inset-x-8 -top-5 z-20 flex items-center justify-center"
+                    >
+                      <span class="border-2 border-border bg-yellow-200 px-4 py-1 font-hero text-lg font-black shadow-shadow">
+                        {constraint_label(@constraint)}
+                      </span>
+                    </div>
                     <%= if @phase == :turn_reveal do %>
                       <div class="absolute inset-x-0 top-0 z-10 m-[2px] flex h-[500px] items-center justify-center bg-white/75 text-center backdrop-blur-[2px]">
                         <div class="flex w-full flex-col items-center gap-4 px-6">
@@ -405,6 +469,7 @@ defmodule FlamingoWeb.ScribbleLive do
                       data-is-drawer={
                         to_string(@player_id == @drawer_id and @participation == :active)
                       }
+                      data-constraint={@constraint}
                       class="flex flex-col gap-2"
                     >
                       <.box class="bg-white p-0">
@@ -750,12 +815,18 @@ defmodule FlamingoWeb.ScribbleLive do
       end
 
     custom_words = Map.get(params, "custom_words", "")
+
+    {game_mode, game_variant} =
+      parse_game_mode(params["game_mode"], socket.assigns.game_mode, socket.assigns.game_variant)
+
     {custom_word_count, custom_words_error} = custom_words_summary(custom_words)
 
     {:noreply,
      assign(socket,
        round_count: round_count,
        turn_length: turn_length,
+       game_mode: game_mode,
+       game_variant: game_variant,
        custom_words: custom_words,
        custom_word_count: custom_word_count,
        custom_words_error: custom_words_error,
@@ -768,11 +839,20 @@ defmodule FlamingoWeb.ScribbleLive do
 
     case Words.parse_custom_words(custom_words) do
       {:ok, words} ->
+        {game_mode, game_variant} =
+          parse_game_mode(
+            params["game_mode"],
+            socket.assigns.game_mode,
+            socket.assigns.game_variant
+          )
+
         settings = %{
           round_count: socket.assigns.round_count,
           turn_length: socket.assigns.turn_length,
           custom_words: words,
-          include_default_words: params["include_default_words"] == "true"
+          include_default_words: params["include_default_words"] == "true",
+          game_mode: game_mode,
+          game_variant: game_variant
         }
 
         case Rooms.start_game(socket.assigns.room_id, settings) do
@@ -827,6 +907,14 @@ defmodule FlamingoWeb.ScribbleLive do
     end
   end
 
+  defp parse_game_mode("telephone", _mode, _variant), do: {:telephone, :classic}
+
+  defp parse_game_mode("constraint_roulette", _mode, _variant),
+    do: {:scribble, :constraint_roulette}
+
+  defp parse_game_mode("classic", _mode, _variant), do: {:scribble, :classic}
+  defp parse_game_mode(_value, mode, variant), do: {mode, variant}
+
   defp custom_words_summary(custom_words) do
     case Words.parse_custom_words(custom_words) do
       {:ok, words} ->
@@ -844,6 +932,14 @@ defmodule FlamingoWeb.ScribbleLive do
     custom_words
     |> String.split(~r/\R/)
     |> Enum.count(&(String.trim(&1) != ""))
+  end
+
+  def handle_info({:room_snapshot, %{mode: :telephone}}, socket) do
+    {:noreply,
+     push_navigate(socket,
+       to:
+         ~p"/game/#{socket.assigns.room_id}/telephone?resume_token=#{socket.assigns.resume_token}"
+     )}
   end
 
   def handle_info({:room_snapshot, snapshot}, socket) do
@@ -869,6 +965,8 @@ defmodule FlamingoWeb.ScribbleLive do
 
     round_count = if sync_settings?, do: snapshot.round_count, else: socket.assigns.round_count
     turn_length = if sync_settings?, do: snapshot.turn_length, else: socket.assigns.turn_length
+    game_mode = if sync_settings?, do: :scribble, else: socket.assigns.game_mode
+    game_variant = if sync_settings?, do: snapshot.game_variant, else: socket.assigns.game_variant
     custom_words = if sync_settings?, do: custom_words, else: socket.assigns.custom_words
 
     custom_word_count =
@@ -883,6 +981,7 @@ defmodule FlamingoWeb.ScribbleLive do
           %{
             "round_count" => Integer.to_string(snapshot.round_count),
             "turn_length" => Integer.to_string(snapshot.turn_length),
+            "game_mode" => selected_game_mode(:scribble, snapshot.game_variant),
             "custom_words" => custom_words,
             "include_default_words" => snapshot.include_default_words
           },
@@ -921,6 +1020,9 @@ defmodule FlamingoWeb.ScribbleLive do
           ),
         round_count: round_count,
         turn_length: turn_length,
+        game_mode: game_mode,
+        game_variant: game_variant,
+        constraint: snapshot.constraint,
         custom_words: custom_words,
         custom_word_count: custom_word_count,
         custom_words_error: custom_words_error,

--- a/lib/flamingo_web/live/telephone_live.ex
+++ b/lib/flamingo_web/live/telephone_live.ex
@@ -1,0 +1,281 @@
+defmodule FlamingoWeb.TelephoneLive do
+  use FlamingoWeb, :live_view
+
+  alias Flamingo.Rooms
+  alias FlamingoWeb.TelephoneComponents
+
+  def mount(%{"room_id" => room_id}, _session, socket) do
+    {:ok,
+     assign(socket,
+       room_id: room_id,
+       resume_token: nil,
+       viewer_id: nil,
+       participation: :spectator,
+       phase: :telephone_draw,
+       players: %{},
+       player_order: [],
+       host_id: nil,
+       turn_length: 30,
+       current_step: nil,
+       step_count: 0,
+       submitted_ids: MapSet.new(),
+       prompt_choices: [],
+       assignment: nil,
+       reveal: nil,
+       votes: %{},
+       vote_counts: %{},
+       awards: %{},
+       custom_words: [],
+       include_default_words: false,
+       turn_end_time: nil,
+       drawing_key: nil,
+       guess_form: to_form(%{"text" => ""}, as: :guess)
+     )}
+  end
+
+  def handle_params(%{"resume_token" => token}, _uri, socket) do
+    if connected?(socket) do
+      case Rooms.connect(socket.assigns.room_id, token) do
+        {:ok, %{mode: :telephone} = snapshot} ->
+          {:noreply, socket |> assign(:resume_token, token) |> apply_snapshot(snapshot)}
+
+        {:ok, _snapshot} ->
+          {:noreply,
+           push_navigate(socket, to: "/game/#{socket.assigns.room_id}?resume_token=#{token}")}
+
+        {:error, _reason} ->
+          {:noreply, push_navigate(socket, to: ~p"/")}
+      end
+    else
+      {:noreply, assign(socket, :resume_token, token)}
+    end
+  end
+
+  def handle_params(_params, _uri, socket),
+    do: {:noreply, push_navigate(socket, to: ~p"/")}
+
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash} background="grid-background">
+      <main id="telephone-game" class="min-h-screen px-3 py-5 sm:px-6 lg:px-8">
+        <div class="mx-auto flex w-full max-w-6xl flex-col gap-4">
+          <header id="telephone-header" class="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <p class="font-hero text-sm font-black tracking-widest text-purple-600 uppercase">
+                Telephone
+              </p>
+              <h1 class="text-2xl font-black sm:text-3xl">Draw it. Guess it. Watch it unravel.</h1>
+            </div>
+            <div
+              :if={@phase in [:telephone_prompt, :telephone_draw, :telephone_guess]}
+              class="flex items-center gap-3"
+            >
+              <span
+                :if={@phase in [:telephone_draw, :telephone_guess]}
+                id="telephone-step-progress"
+                class="rounded-full border-2 border-border bg-white px-4 py-2 font-bold shadow-shadow"
+              >
+                Step {if(is_integer(@current_step), do: @current_step + 1, else: "–")} of {max(
+                  @step_count,
+                  1
+                )}
+              </span>
+              <span
+                id="telephone-timer"
+                phx-hook=".TelephoneTimer"
+                phx-update="ignore"
+                data-end-time={iso_time(@turn_end_time)}
+                class="min-w-16 rounded-full border-2 border-border bg-yellow-200 px-4 py-2 text-center font-hero text-xl font-black tabular-nums shadow-shadow"
+              >
+                --
+              </span>
+            </div>
+          </header>
+
+          <%= case @phase do %>
+            <% :telephone_prompt -> %>
+              <TelephoneComponents.prompt_phase
+                choices={@prompt_choices}
+                submitted={submitted?(assigns)}
+              />
+            <% :telephone_draw -> %>
+              <TelephoneComponents.draw_phase
+                assignment={@assignment}
+                submitted={submitted?(assigns)}
+              />
+            <% :telephone_guess -> %>
+              <TelephoneComponents.guess_phase
+                assignment={@assignment}
+                submitted={submitted?(assigns)}
+                form={@guess_form}
+              />
+            <% :telephone_reveal -> %>
+              <TelephoneComponents.reveal_phase
+                reveal={@reveal}
+                players={@players}
+                viewer_id={@viewer_id}
+                host_id={@host_id}
+                participation={@participation}
+                votes={@votes}
+                vote_counts={@vote_counts}
+              />
+            <% :game_ended -> %>
+              <TelephoneComponents.awards_phase
+                awards={@awards}
+                players={@players}
+                host?={@viewer_id == @host_id}
+              />
+            <% _ -> %>
+              <.box class="bg-white p-10 text-center">
+                <p id="telephone-loading" class="text-xl font-bold">Getting the next link ready…</p>
+              </.box>
+          <% end %>
+        </div>
+      </main>
+
+      <script :type={Phoenix.LiveView.ColocatedHook} name=".TelephoneTimer">
+        export default {
+          mounted() {
+            this.run = (endTime) => {
+              this.token = (this.token || 0) + 1
+              const token = this.token
+              const end = endTime ? new Date(endTime).getTime() : NaN
+              const tick = () => {
+                if (token !== this.token) return
+                const seconds = Number.isFinite(end) ? Math.max(0, Math.ceil((end - Date.now()) / 1000)) : 0
+                this.el.textContent = Number.isFinite(end) ? String(seconds).padStart(2, "0") : "--"
+                if (seconds > 0) requestAnimationFrame(tick)
+              }
+              tick()
+            }
+            this.run(this.el.dataset.endTime)
+            this.handleEvent("set_telephone_timer", ({end_time}) => this.run(end_time))
+          },
+          destroyed() { this.token = (this.token || 0) + 1 }
+        }
+      </script>
+    </Layouts.app>
+    """
+  end
+
+  def handle_event("draw_event", event, socket) do
+    Rooms.draw_event(socket.assigns.room_id, event)
+    {:noreply, socket}
+  end
+
+  def handle_event("select_prompt", %{"prompt" => prompt}, socket),
+    do: command(socket, {:select_prompt, prompt})
+
+  def handle_event("submit_drawing", _params, socket), do: command(socket, :submit_drawing)
+
+  def handle_event("submit_guess", %{"guess" => %{"text" => text}}, socket) do
+    command(socket, {:submit_guess, text}, reset_form?: true)
+  end
+
+  def handle_event("advance_reveal", _params, socket), do: command(socket, :advance_reveal)
+
+  def handle_event("vote", %{"category" => category, "entry-id" => entry_id}, socket) do
+    category =
+      Enum.find([:derailment, :best_save, :worst_drawing], &(Atom.to_string(&1) == category))
+
+    if category, do: command(socket, {:vote, category, entry_id}), else: {:noreply, socket}
+  end
+
+  def handle_event("play_again", _params, socket) do
+    settings = %{
+      game_mode: :telephone,
+      turn_length: socket.assigns.turn_length,
+      custom_words: socket.assigns.custom_words,
+      include_default_words: socket.assigns.include_default_words
+    }
+
+    result(socket, Rooms.start_game(socket.assigns.room_id, settings))
+  end
+
+  def handle_info({:room_snapshot, %{mode: :telephone} = snapshot}, socket),
+    do: {:noreply, apply_snapshot(socket, snapshot)}
+
+  def handle_info({:draw_event, %{actor_id: actor_id, event: event}}, socket) do
+    if actor_id == socket.assigns.viewer_id,
+      do: {:noreply, push_event(socket, "draw_event", event)},
+      else: {:noreply, socket}
+  end
+
+  def handle_info(_message, socket), do: {:noreply, socket}
+
+  defp command(socket, command, opts \\ []) do
+    case Rooms.command(socket.assigns.room_id, command) do
+      :ok ->
+        socket =
+          if opts[:reset_form?],
+            do: assign(socket, :guess_form, to_form(%{"text" => ""}, as: :guess)),
+            else: socket
+
+        {:noreply, socket}
+
+      {:error, reason} ->
+        {:noreply, put_flash(socket, :error, command_error(reason))}
+
+      other ->
+        result(socket, other)
+    end
+  end
+
+  defp result(socket, :ok), do: {:noreply, socket}
+
+  defp result(socket, {:error, reason}),
+    do: {:noreply, put_flash(socket, :error, command_error(reason))}
+
+  defp result(socket, _), do: {:noreply, socket}
+
+  defp apply_snapshot(socket, snapshot) do
+    assignment = Map.get(snapshot, :assignment)
+    key = assignment && {Map.get(snapshot, :current_step), assignment.chain_id}
+    baseline? = key != socket.assigns.drawing_key and Map.get(snapshot, :phase) == :telephone_draw
+
+    socket =
+      assign(socket,
+        viewer_id: snapshot.viewer_id,
+        participation: snapshot.participation,
+        phase: snapshot.phase,
+        players: snapshot.players,
+        player_order: snapshot.player_order,
+        host_id: snapshot.host_id,
+        turn_length: snapshot.turn_length,
+        current_step: snapshot.current_step,
+        step_count: snapshot.step_count,
+        submitted_ids: snapshot.submitted_ids,
+        prompt_choices: Map.get(snapshot, :prompt_choices, []),
+        assignment: assignment,
+        reveal: snapshot.reveal,
+        votes: snapshot.votes,
+        vote_counts: snapshot.vote_counts,
+        awards: snapshot.awards,
+        custom_words: snapshot.custom_words,
+        include_default_words: snapshot.include_default_words,
+        turn_end_time: Map.get(snapshot, :turn_end_time),
+        drawing_key: key
+      )
+
+    socket =
+      if baseline?,
+        do:
+          push_event(socket, "drawing_state", %{events: Map.get(assignment, :current_drawing, [])}),
+        else: socket
+
+    push_event(socket, "set_telephone_timer", %{
+      end_time: iso_time(Map.get(snapshot, :turn_end_time))
+    })
+  end
+
+  defp submitted?(assigns), do: MapSet.member?(assigns.submitted_ids, assigns.viewer_id)
+  defp iso_time(%DateTime{} = value), do: DateTime.to_iso8601(value)
+  defp iso_time(value) when is_binary(value), do: value
+  defp iso_time(_), do: nil
+  defp command_error(:invalid_prompt), do: "Choose one of the prompts shown."
+  defp command_error(:invalid_guess), do: "Add a guess between 1 and 100 characters."
+  defp command_error(:already_submitted), do: "You already sent this link."
+  defp command_error(:not_host), do: "Only the host can do that."
+  defp command_error(:cannot_submit), do: "That drawing can no longer be submitted."
+  defp command_error(reason), do: "That didn't work (#{reason}). Please try again."
+end

--- a/lib/flamingo_web/router.ex
+++ b/lib/flamingo_web/router.ex
@@ -19,6 +19,7 @@ defmodule FlamingoWeb.Router do
 
     live "/", HomeLive
     live "/game/:room_id", ScribbleLive
+    live "/game/:room_id/telephone", TelephoneLive
     live "/drawing", DrawingLive
   end
 

--- a/test/flamingo/game_modes/scribble_test.exs
+++ b/test/flamingo/game_modes/scribble_test.exs
@@ -24,7 +24,7 @@ defmodule Flamingo.GameModes.ScribbleTest do
       word_choices: fn _count, used, _custom, _defaults ->
         Enum.reject(["cat", "dog", "bird"], &MapSet.member?(used, &1))
       end,
-      select_candidate: &List.first/1
+      select_candidate: Keyword.get(options, :select_candidate, &List.first/1)
     }
   end
 
@@ -86,6 +86,63 @@ defmodule Flamingo.GameModes.ScribbleTest do
     assert restarted.scores == %{"a" => 10, "b" => 20}
     assert Enum.take(restarted.feed.events, length(feed.events)) == feed.events
     assert restarted.used_words == MapSet.new()
+  end
+
+  test "constraint roulette selects and projects a constraint for each turn" do
+    pick_last = fn candidates -> List.last(candidates) end
+
+    {:ok, %{state: roulette}} =
+      Scribble.start(
+        admitted(),
+        %{round_count: 1, game_variant: :constraint_roulette},
+        context(select_candidate: pick_last)
+      )
+
+    assert roulette.constraint == :mirror
+    assert Scribble.view(roulette, "b", roster()).constraint == :mirror
+    assert Scribble.view(roulette, "b", roster()).game_variant == :constraint_roulette
+
+    {:ok, %{state: classic}} = Scribble.start(admitted(), %{round_count: 1}, context())
+    assert classic.constraint == nil
+  end
+
+  test "single-stroke and straight-line constraints are enforced by the game" do
+    drawing_state = %{
+      admitted()
+      | phase: :playing,
+        drawer_id: "a",
+        word: "cat",
+        constraint: :single_stroke
+    }
+
+    start_event = %{"event_type" => "start", "x" => 1, "y" => 1}
+    end_event = %{"event_type" => "end", "end_x" => 2, "end_y" => 2}
+
+    {:ok, %{state: drawing_state}} =
+      Scribble.command(drawing_state, "a", {:draw, start_event}, context())
+
+    {:ok, %{state: drawing_state}} =
+      Scribble.command(drawing_state, "a", {:draw, end_event}, context())
+
+    assert :ignored == Scribble.command(drawing_state, "a", {:draw, start_event}, context())
+
+    assert :ignored ==
+             Scribble.command(drawing_state, "a", {:draw, %{"event_type" => "clear"}}, context())
+
+    straight_state = %{drawing_state | constraint: :straight_lines, current_drawing: []}
+
+    assert :ignored ==
+             Scribble.command(
+               straight_state,
+               "a",
+               {:draw, %{"event_type" => "draw"}},
+               context()
+             )
+
+    assert {:ok, _result} =
+             Scribble.command(straight_state, "a", {:draw, start_event}, context())
+
+    assert :ignored == Scribble.command(straight_state, "a", {:draw, end_event}, context())
   end
 
   test "lobby and game-ended admits are active and final results remain immutable on removal" do

--- a/test/flamingo/game_modes/telephone_test.exs
+++ b/test/flamingo/game_modes/telephone_test.exs
@@ -1,0 +1,361 @@
+defmodule Flamingo.GameModes.TelephoneTest do
+  use ExUnit.Case, async: true
+
+  alias Flamingo.GameModes.Telephone
+
+  defp roster(order) do
+    names = %{"a" => "Alice", "b" => "Bob", "c" => "Cara", "s" => "Sam"}
+
+    %{
+      players: Map.new(order, &{&1, %{id: &1, name: names[&1], connected: true}}),
+      player_order: order,
+      host_id: "a"
+    }
+  end
+
+  defp context(roster, actor \\ "a") do
+    %{
+      roster: roster,
+      actor_id: actor,
+      now: ~U[2026-01-01 00:00:00Z],
+      word_choices: fn _count, _used, _custom, _defaults -> ["cat", "dog", "bird"] end,
+      select_candidate: &List.first/1
+    }
+  end
+
+  defp started(order \\ ["a", "b", "c"], opts \\ []) do
+    game_roster = roster(order)
+
+    state =
+      Enum.reduce(order, Telephone.new(), fn id, state ->
+        {:ok, %{state: state}} =
+          Telephone.admit_member(state, game_roster.players[id], context(game_roster))
+
+        state
+      end)
+
+    {:ok, %{state: state}} =
+      Telephone.start(state, %{turn_length: 15}, context(game_roster))
+
+    state =
+      if Keyword.get(opts, :choose_prompts, true) do
+        Enum.reduce(order, state, fn id, state ->
+          prompt = state.prompt_choices |> Map.fetch!(id) |> List.first()
+
+          {:ok, %{state: state}} =
+            Telephone.command(state, id, {:select_prompt, prompt}, context(game_roster, id))
+
+          state
+        end)
+      else
+        state
+      end
+
+    {state, game_roster}
+  end
+
+  defp submit_everyone(state, game_roster) do
+    Enum.reduce(game_roster.player_order, state, fn id, state ->
+      result =
+        if state.phase == :telephone_draw,
+          do: Telephone.command(state, id, :submit_drawing, context(game_roster)),
+          else: Telephone.command(state, id, {:submit_guess, "guess #{id}"}, context(game_roster))
+
+      {:ok, %{state: state}} = result
+      state
+    end)
+  end
+
+  test "players privately choose the prompts that start their chains" do
+    {state, game_roster} = started(["a", "b"], choose_prompts: false)
+
+    assert state.phase == :telephone_prompt
+    assert Telephone.view(state, "a", game_roster).prompt_choices == ["cat", "dog", "bird"]
+    assert Telephone.view(state, "b", game_roster).prompt_choices == ["dog", "bird", "cat"]
+
+    {:ok, %{state: state}} =
+      Telephone.command(state, "a", {:select_prompt, "bird"}, context(game_roster, "a"))
+
+    assert state.phase == :telephone_prompt
+    assert MapSet.member?(state.submitted, "a")
+
+    assert {:error, :invalid_prompt} =
+             Telephone.command(
+               state,
+               "b",
+               {:select_prompt, "not offered"},
+               context(game_roster, "b")
+             )
+
+    {:ok, %{state: state}} =
+      Telephone.command(state, "b", {:select_prompt, "dog"}, context(game_roster, "b"))
+
+    assert state.phase == :telephone_draw
+    assert Enum.map(state.chains, &hd(&1.entries).value) == ["bird", "dog"]
+  end
+
+  test "rotates chains, alternates phases, and keeps drawings viewer-private" do
+    {state, game_roster} = started()
+    assert Telephone.view(state, "a", game_roster).assignment.chain_id == "telephone-chain-0"
+
+    event = %{
+      "event_type" => "start",
+      "x" => 1,
+      "y" => 2,
+      "color" => "#000000",
+      "line_width" => 4
+    }
+
+    {:ok, %{state: state, drawing_delta: delta, drawing_scope: :actor}} =
+      Telephone.command(state, "a", {:draw, event}, context(game_roster))
+
+    assert delta == %{actor_id: "a", event: event}
+    assert Telephone.view(state, "a", game_roster).assignment.current_drawing == [event]
+    assert Telephone.view(state, "b", game_roster).assignment.current_drawing == []
+
+    state = submit_everyone(state, game_roster)
+    assert state.phase == :telephone_guess
+    assert Telephone.view(state, "a", game_roster).assignment.chain_id == "telephone-chain-2"
+    assert Telephone.view(state, "a", game_roster).assignment.source.type == :drawing
+
+    state = submit_everyone(state, game_roster)
+    assert state.phase == :telephone_draw
+    assert Telephone.view(state, "a", game_roster).assignment.chain_id == "telephone-chain-1"
+    assert Telephone.view(state, "a", game_roster).assignment.source.value == "guess c"
+  end
+
+  test "timeout records placeholders and a disconnect completes the online set" do
+    {state, game_roster} = started(["a", "b"])
+    {:ok, %{state: state}} = Telephone.command(state, "a", :submit_drawing, context(game_roster))
+
+    offline_roster = put_in(game_roster.players["b"].connected, false)
+
+    {:ok, %{state: state}} =
+      Telephone.connection_changed(state, "b", :offline, context(offline_roster))
+
+    assert state.phase == :telephone_guess
+    assert Enum.at(state.chains, 1).entries |> List.last() |> Map.fetch!(:value) == nil
+
+    {:ok, %{state: reveal}} = Telephone.timeout(state, :telephone_step, context(offline_roster))
+    assert reveal.phase == :telephone_reveal
+    assert Enum.all?(reveal.chains, &(length(&1.entries) == 3))
+  end
+
+  test "a transient fully-offline room does not skip a step" do
+    {state, game_roster} = started(["a", "b"])
+
+    offline_roster =
+      update_in(game_roster.players, fn players ->
+        Map.new(players, fn {id, player} -> {id, %{player | connected: false}} end)
+      end)
+
+    {:ok, %{state: unchanged}} =
+      Telephone.connection_changed(state, "a", :offline, context(offline_roster))
+
+    assert unchanged.phase == :telephone_draw
+    assert unchanged.current_step == 0
+    assert Enum.all?(unchanged.chains, &(length(&1.entries) == 1))
+  end
+
+  test "rejects restarts, stale commands, and malformed drawing events" do
+    {state, game_roster} = started(["a", "b"])
+
+    assert {:error, :game_in_progress} =
+             Telephone.start(state, %{turn_length: 15}, context(game_roster))
+
+    assert {:error, :invalid_command} =
+             Telephone.command(state, "a", {:guess, "stale"}, context(game_roster))
+
+    assert {:error, :invalid_draw_event} =
+             Telephone.command(state, "a", {:draw, "not a map"}, context(game_roster))
+
+    assert :ignored =
+             Telephone.command(
+               state,
+               "a",
+               {:draw, %{"event_type" => "start", "x" => 1}},
+               context(game_roster)
+             )
+  end
+
+  test "players admitted after start spectate and captured snapshots survive removal" do
+    {state, game_roster} = started(["a", "b"])
+    expanded = %{roster(["a", "b", "s"]) | host_id: "a"}
+
+    {:ok, %{state: state}} =
+      Telephone.admit_member(state, expanded.players["s"], context(expanded))
+
+    assert state.participants["s"] == :spectator
+    assert Telephone.view(state, "s", expanded).assignment == nil
+
+    assert :ignored ==
+             Telephone.command(state, "s", {:draw, %{"event_type" => "clear"}}, context(expanded))
+
+    reveal = %{state | phase: :telephone_reveal, reveal_chain_index: 0, reveal_entry_index: 0}
+    prompt = hd(hd(reveal.chains).entries)
+
+    assert {:error, :spectator} =
+             Telephone.command(
+               reveal,
+               "s",
+               {:vote, :best_save, prompt.id},
+               context(expanded)
+             )
+
+    removed_roster = %{
+      game_roster
+      | players: Map.delete(game_roster.players, "b"),
+        player_order: ["a"]
+    }
+
+    {:ok, %{state: state}} =
+      Telephone.remove_member(state, "b", %{name: "Bob"}, context(removed_roster))
+
+    assert state.player_order == ["a", "b"]
+    assert state.players["b"].name == "Bob"
+  end
+
+  test "a new match promotes spectators and a removed host transfers reveal control" do
+    {state, _game_roster} = started(["a", "b"])
+    expanded = %{roster(["a", "b", "s"]) | host_id: "a"}
+
+    {:ok, %{state: state}} =
+      Telephone.admit_member(state, expanded.players["s"], context(expanded))
+
+    assert state.participants["s"] == :spectator
+
+    ended = %{state | phase: :game_ended}
+    {:ok, %{state: restarted}} = Telephone.start(ended, %{turn_length: 15}, context(expanded))
+    assert restarted.player_order == ["a", "b", "s"]
+    assert restarted.participants["s"] == :active
+
+    restarted =
+      Enum.reduce(restarted.player_order, restarted, fn id, state ->
+        prompt = state.prompt_choices |> Map.fetch!(id) |> List.first()
+
+        {:ok, %{state: state}} =
+          Telephone.command(state, id, {:select_prompt, prompt}, context(expanded, id))
+
+        state
+      end)
+
+    new_roster = %{expanded | players: Map.delete(expanded.players, "a"), host_id: "b"}
+
+    {:ok, %{state: migrated}} =
+      Telephone.remove_member(
+        %{
+          restarted
+          | phase: :telephone_reveal,
+            reveal_chain_index: 0,
+            reveal_entry_index: 0
+        },
+        "a",
+        %{name: "Alice"},
+        context(new_roster)
+      )
+
+    assert migrated.host_id == "b"
+    assert {:ok, _result} = Telephone.command(migrated, "b", :advance_reveal, context(new_roster))
+  end
+
+  test "a new host can continue reveal after every original player is removed" do
+    {state, game_roster} = started(["a", "b"])
+    reveal = state |> submit_everyone(game_roster) |> submit_everyone(game_roster)
+
+    bob_roster = %{
+      game_roster
+      | players: Map.delete(game_roster.players, "a"),
+        player_order: ["b"],
+        host_id: "b"
+    }
+
+    {:ok, %{state: reveal}} =
+      Telephone.remove_member(reveal, "a", %{name: "Alice"}, context(bob_roster))
+
+    empty_roster = %{players: %{}, player_order: [], host_id: nil}
+
+    {:ok, %{state: reveal}} =
+      Telephone.remove_member(reveal, "b", %{name: "Bob"}, context(empty_roster))
+
+    assert reveal.host_id == nil
+
+    sam_roster = %{roster(["s"]) | host_id: "s"}
+
+    {:ok, %{state: reveal}} =
+      Telephone.admit_member(reveal, sam_roster.players["s"], context(sam_roster, "s"))
+
+    assert reveal.host_id == "s"
+
+    assert {:ok, _result} =
+             Telephone.command(reveal, "s", :advance_reveal, context(sam_roster, "s"))
+  end
+
+  test "host paces leak-free reveal, votes can change, and awards finish deterministically" do
+    {state, game_roster} = started(["a", "b"])
+    state = state |> submit_everyone(game_roster) |> submit_everyone(game_roster)
+    assert state.phase == :telephone_reveal
+
+    view = Telephone.view(state, "b", game_roster)
+    assert length(view.reveal.chain.entries) == 1
+    refute inspect(view.reveal) =~ "guess b"
+
+    assert {:error, :not_host} =
+             Telephone.command(state, "b", :advance_reveal, context(game_roster, "b"))
+
+    future_drawing = Enum.at(state.chains, 0).entries |> Enum.at(1)
+
+    assert {:error, :entry_not_revealed} =
+             Telephone.command(
+               state,
+               "b",
+               {:vote, :worst_drawing, future_drawing.id},
+               context(game_roster)
+             )
+
+    {:ok, %{state: state}} = Telephone.command(state, "a", :advance_reveal, context(game_roster))
+
+    {:ok, %{state: state}} =
+      Telephone.command(
+        state,
+        "b",
+        {:vote, :worst_drawing, future_drawing.id},
+        context(game_roster)
+      )
+
+    prompt = hd(hd(state.chains).entries)
+
+    assert {:error, :invalid_entry} =
+             Telephone.command(
+               state,
+               "b",
+               {:vote, :worst_drawing, prompt.id},
+               context(game_roster)
+             )
+
+    assert {:error, :invalid_entry} =
+             Telephone.command(
+               state,
+               "b",
+               {:vote, :best_save, prompt.id},
+               context(game_roster)
+             )
+
+    {:ok, %{state: state}} =
+      Telephone.command(state, "b", {:vote, :best_save, future_drawing.id}, context(game_roster))
+
+    assert Telephone.view(state, "b", game_roster).vote_counts.best_save == %{
+             future_drawing.id => 1
+           }
+
+    {:ok, %{state: state}} = Telephone.command(state, "a", :advance_reveal, context(game_roster))
+    {:ok, %{state: state}} = Telephone.command(state, "a", :advance_reveal, context(game_roster))
+    {:ok, %{state: state}} = Telephone.command(state, "a", :advance_reveal, context(game_roster))
+    {:ok, %{state: state}} = Telephone.command(state, "a", :advance_reveal, context(game_roster))
+    {:ok, result} = Telephone.command(state, "a", :advance_reveal, context(game_roster))
+
+    assert result.state.phase == :game_ended
+    assert {:finished, result.state.final_result} == result.status
+    assert result.state.awards.worst_drawing.player_id == "a"
+    assert result.state.awards.best_save.entry.id == future_drawing.id
+  end
+end

--- a/test/flamingo/room/members_test.exs
+++ b/test/flamingo/room/members_test.exs
@@ -61,6 +61,16 @@ defmodule Flamingo.Room.MembersTest do
     assert Members.host_id(members) == nil
   end
 
+  test "removing the host prefers an online successor" do
+    {:ok, members} = Members.add(Members.new(), "alice", "alice-token", "Alice")
+    {:ok, members} = Members.add(members, "bob", "bob-token", "Bob")
+    {:ok, members} = Members.add(members, "cara", "cara-token", "Cara")
+    {:ok, members, :became_online} = Members.connection_added(members, "cara")
+
+    assert {:ok, members, %{id: "alice"}} = Members.remove(members, "alice")
+    assert Members.host_id(members) == "cara"
+  end
+
   test "duplicate seat IDs and resume tokens are rejected" do
     {:ok, members} = Members.add(Members.new(), "alice", "alice-token", "Alice")
 

--- a/test/flamingo/room_server_test.exs
+++ b/test/flamingo/room_server_test.exs
@@ -97,6 +97,9 @@ defmodule Flamingo.RoomServerTest do
   defp guess_as(room_id, token, guess),
     do: as_player(token, fn -> Rooms.guess(room_id, guess) end)
 
+  defp command_as(room_id, token, command),
+    do: as_player(token, fn -> Rooms.command(room_id, command) end)
+
   defp draw_event_as(room_id, token, event),
     do: as_player(token, fn -> Rooms.draw_event(room_id, event) end)
 
@@ -425,6 +428,80 @@ defmodule Flamingo.RoomServerTest do
 
     {:ok, state} = room_snapshot(room_id)
     assert state.current_drawing == [first_event]
+  end
+
+  test "telephone dispatches private drawings and advances simultaneous players", %{
+    room_id: room_id
+  } do
+    {:ok, alice_token, %{viewer_id: alice}} = join_connected(room_id, "Alice")
+    {:ok, bob_token, %{viewer_id: bob}} = join_connected(room_id, "Bob")
+
+    assert :ok =
+             start_game_as(room_id, alice_token, %{
+               game_mode: :telephone,
+               turn_length: 30,
+               custom_words: ["cat", "dog"]
+             })
+
+    {:ok, alice_snapshot} = snapshot_as(room_id, alice_token)
+    {:ok, bob_snapshot} = snapshot_as(room_id, bob_token)
+    assert alice_snapshot.mode == :telephone
+    assert alice_snapshot.phase == :telephone_prompt
+    assert alice_snapshot.prompt_choices != []
+    assert bob_snapshot.prompt_choices != []
+
+    assert :ok =
+             command_as(
+               room_id,
+               alice_token,
+               {:select_prompt, List.first(alice_snapshot.prompt_choices)}
+             )
+
+    assert :ok =
+             command_as(
+               room_id,
+               bob_token,
+               {:select_prompt, List.first(bob_snapshot.prompt_choices)}
+             )
+
+    {:ok, alice_snapshot} = snapshot_as(room_id, alice_token)
+    {:ok, bob_snapshot} = snapshot_as(room_id, bob_token)
+    assert alice_snapshot.phase == :telephone_draw
+    assert alice_snapshot.assignment.chain_id != bob_snapshot.assignment.chain_id
+
+    timer_generation = runtime_state(room_id).phase_timer.generation
+
+    assert {:error, :game_in_progress} =
+             start_game_as(room_id, alice_token, %{game_mode: :scribble})
+
+    assert runtime_state(room_id).game_module == Flamingo.GameModes.Telephone
+    assert runtime_state(room_id).phase_timer.generation == timer_generation
+
+    assert {:error, :invalid_game_mode} =
+             start_game_as(room_id, alice_token, %{game_mode: :unknown})
+
+    flush_room_snapshots()
+    event = %{"event_type" => "clear"}
+    :ok = draw_event_as(room_id, alice_token, event)
+    _ = :sys.get_state(room_pid(room_id))
+
+    bob_pid = Process.get({:player, bob_token})
+    refute_receive {:draw_event, ^bob_pid, _event}
+
+    assert snapshot_as(room_id, alice_token)
+           |> elem(1)
+           |> Map.fetch!(:assignment)
+           |> Map.fetch!(:current_drawing) == [event]
+
+    assert bob not in alice_snapshot.submitted_ids
+    assert alice not in alice_snapshot.submitted_ids
+
+    assert :ok = command_as(room_id, alice_token, :submit_drawing)
+    assert :ok = command_as(room_id, bob_token, :submit_drawing)
+
+    {:ok, next_snapshot} = snapshot_as(room_id, alice_token)
+    assert next_snapshot.phase == :telephone_guess
+    assert next_snapshot.assignment.source.type == :drawing
   end
 
   test "a duplicate drawer connection receives deltas and a reconnect baseline", %{

--- a/test/flamingo_web/live/scribble_live_test.exs
+++ b/test/flamingo_web/live/scribble_live_test.exs
@@ -149,6 +149,43 @@ defmodule FlamingoWeb.ScribbleLiveTest do
     assert state.include_default_words
   end
 
+  test "host can start constraint roulette", %{conn: conn, room_id: room_id} do
+    {:ok, p1_token, _p1_snapshot} = join_connected(room_id, "Alice")
+    {:ok, _p2_token, _p2_snapshot} = join_connected(room_id, "Bob")
+
+    {:ok, view, _html} = live(conn, ~p"/game/#{room_id}?resume_token=#{p1_token}")
+
+    assert has_element?(view, "input[name='settings[game_mode]'][value='classic']:checked")
+
+    view
+    |> form("#settings-form", %{
+      "settings" => %{
+        "round_count" => "1",
+        "turn_length" => "30",
+        "game_mode" => "constraint_roulette"
+      }
+    })
+    |> render_submit()
+
+    {:ok, state} = room_snapshot(room_id)
+    assert state.game_variant == :constraint_roulette
+
+    assert state.constraint in [
+             :hidden_canvas,
+             :single_stroke,
+             :straight_lines,
+             :rotating_canvas,
+             :mirror
+           ]
+
+    view
+    |> element("button[phx-click='select_word']", List.first(state.word_choices))
+    |> render_click()
+
+    assert has_element?(view, "#constraint-banner")
+    assert has_element?(view, "#drawing-canvas[data-constraint]")
+  end
+
   test "custom word validation is shown before starting", %{conn: conn, room_id: room_id} do
     {:ok, p1_token, _p1_snapshot} = join_connected(room_id, "Alice")
     {:ok, _p2_token, _p2_snapshot} = join_connected(room_id, "Bob")

--- a/test/flamingo_web/live/telephone_live_test.exs
+++ b/test/flamingo_web/live/telephone_live_test.exs
@@ -1,0 +1,298 @@
+defmodule FlamingoWeb.TelephoneLiveTest do
+  use FlamingoWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Flamingo.{RoomSupervisor, Rooms}
+
+  defp join_connected(room_id, name) do
+    parent = self()
+
+    pid =
+      start_supervised!(
+        Supervisor.child_spec(
+          {Task, fn -> connected_player(parent, room_id, name) end},
+          id: {:telephone_player, make_ref()}
+        )
+      )
+
+    assert_receive {:connected, ^pid, token, snapshot}
+    Process.put({:telephone_player, token}, pid)
+    {token, snapshot}
+  end
+
+  defp connected_player(parent, room_id, name) do
+    {:ok, token, _snapshot} = Rooms.join(room_id, name)
+    {:ok, snapshot} = Rooms.connect(room_id, token)
+    send(parent, {:connected, self(), token, snapshot})
+    player_loop()
+  end
+
+  defp player_loop do
+    receive do
+      {:call, caller, ref, operation} ->
+        send(caller, {ref, operation.()})
+        player_loop()
+
+      _room_message ->
+        player_loop()
+    end
+  end
+
+  defp as_player(token, operation) do
+    pid = Process.get({:telephone_player, token})
+    assert is_pid(pid)
+    ref = make_ref()
+    send(pid, {:call, self(), ref, operation})
+    assert_receive {^ref, result}
+    result
+  end
+
+  defp command_as(room_id, token, command),
+    do: as_player(token, fn -> Rooms.command(room_id, command) end)
+
+  defp draw_event_as(room_id, token, event),
+    do: as_player(token, fn -> Rooms.draw_event(room_id, event) end)
+
+  defp snapshot_as(room_id, token),
+    do: as_player(token, fn -> Rooms.snapshot(room_id) end)
+
+  defp room_pid(room_id), do: :global.whereis_name({:flamingo_room, room_id})
+
+  defp start_telephone(room_id, host_token, other_token) do
+    :ok =
+      as_player(host_token, fn ->
+        Rooms.start_game(room_id, %{
+          game_mode: :telephone,
+          turn_length: 30,
+          custom_words: ["orbital llama", "velvet cactus"],
+          include_default_words: false
+        })
+      end)
+
+    _ = :sys.get_state(room_pid(room_id))
+
+    {:ok, host_snapshot} = snapshot_as(room_id, host_token)
+    {:ok, other_snapshot} = snapshot_as(room_id, other_token)
+
+    :ok =
+      command_as(
+        room_id,
+        host_token,
+        {:select_prompt, List.first(host_snapshot.prompt_choices)}
+      )
+
+    :ok =
+      command_as(
+        room_id,
+        other_token,
+        {:select_prompt, List.first(other_snapshot.prompt_choices)}
+      )
+
+    _ = :sys.get_state(room_pid(room_id))
+  end
+
+  setup do
+    room_id = "telephone-live-#{System.unique_integer([:positive])}"
+    {:ok, ^room_id} = RoomSupervisor.start_room(room_id)
+    %{room_id: room_id}
+  end
+
+  test "host selects Telephone in the lobby and follows the redirect into a private draw", %{
+    conn: conn,
+    room_id: room_id
+  } do
+    {host_token, _} = join_connected(room_id, "Alice")
+    {other_token, _} = join_connected(room_id, "Bob")
+    {:ok, lobby, _html} = live(conn, ~p"/game/#{room_id}?resume_token=#{host_token}")
+
+    lobby
+    |> form("#settings-form", %{
+      "settings" => %{
+        "round_count" => "1",
+        "turn_length" => "30",
+        "game_mode" => "telephone",
+        "custom_words" => "orbital llama\nvelvet cactus",
+        "include_default_words" => "false"
+      }
+    })
+    |> render_submit()
+
+    path = "/game/#{room_id}/telephone?resume_token=#{host_token}"
+    assert_redirect(lobby, path)
+    {:ok, telephone, _html} = live(conn, path)
+
+    assert has_element?(telephone, "#telephone-prompt-phase")
+    assert has_element?(telephone, "#telephone-prompt-choices button")
+
+    telephone |> element("#telephone-prompt-choices button", "orbital llama") |> render_click()
+    assert has_element?(telephone, "#prompt-submitted-waiting")
+
+    {:ok, other_snapshot} = snapshot_as(room_id, other_token)
+
+    :ok =
+      command_as(
+        room_id,
+        other_token,
+        {:select_prompt, List.first(other_snapshot.prompt_choices)}
+      )
+
+    _ = :sys.get_state(room_pid(room_id))
+
+    assert has_element?(telephone, "#telephone-draw-phase")
+
+    assert has_element?(telephone, "#draw-source-text", "orbital llama") or
+             has_element?(telephone, "#draw-source-text", "velvet cactus")
+
+    assert has_element?(telephone, "#telephone-drawing-canvas canvas")
+    assert has_element?(telephone, "#submit-telephone-drawing")
+  end
+
+  test "two players receive private chains and progress through draw, guess, and leak-free reveal",
+       %{
+         conn: conn,
+         room_id: room_id
+       } do
+    {host_token, %{viewer_id: host_id}} = join_connected(room_id, "Alice")
+    {bob_token, %{viewer_id: bob_id}} = join_connected(room_id, "Bob")
+    start_telephone(room_id, host_token, bob_token)
+
+    {:ok, host, _html} =
+      live(conn, ~p"/game/#{room_id}/telephone?resume_token=#{host_token}")
+
+    {:ok, bob_snapshot} = snapshot_as(room_id, bob_token)
+    assert bob_snapshot.viewer_id == bob_id
+    assert bob_snapshot.assignment.chain_id != nil
+    refute has_element?(host, "#draw-source-text", bob_snapshot.assignment.source.value)
+    assert host_id != bob_id
+
+    start_event = %{
+      "event_type" => "start",
+      "x" => 40,
+      "y" => 50,
+      "color" => "#EF120B",
+      "line_width" => 9
+    }
+
+    end_event = %{
+      "event_type" => "end",
+      "start_x" => 40,
+      "start_y" => 50,
+      "end_x" => 180,
+      "end_y" => 160,
+      "color" => "#EF120B",
+      "line_width" => 9
+    }
+
+    host |> element("#telephone-drawing-canvas") |> render_hook("draw_event", start_event)
+    host |> element("#telephone-drawing-canvas") |> render_hook("draw_event", end_event)
+    :ok = draw_event_as(room_id, bob_token, start_event)
+    :ok = draw_event_as(room_id, bob_token, end_event)
+    _ = :sys.get_state(room_pid(room_id))
+
+    host |> element("#submit-telephone-drawing") |> render_click()
+    assert has_element?(host, "#drawing-submitted-overlay")
+    :ok = command_as(room_id, bob_token, :submit_drawing)
+    _ = :sys.get_state(room_pid(room_id))
+
+    assert has_element?(host, "#telephone-guess-phase")
+    assert has_element?(host, "#telephone-guess-drawing")
+    assert has_element?(host, "#telephone-guess-drawing:not([data-final-drawing-events='[]'])")
+    assert has_element?(host, "#telephone-guess-drawing svg polyline")
+    assert has_element?(host, "#telephone-guess-form")
+
+    host
+    |> form("#telephone-guess-form", %{"guess" => %{"text" => "a moon llama"}})
+    |> render_submit()
+
+    assert has_element?(host, "#guess-submitted-waiting")
+    :ok = command_as(room_id, bob_token, {:submit_guess, "a cactus moon"})
+    _ = :sys.get_state(room_pid(room_id))
+
+    assert has_element?(host, "#telephone-reveal-phase")
+    assert has_element?(host, "#revealed-entries article")
+    refute has_element?(host, "#revealed-entries article:nth-child(2)")
+    assert has_element?(host, "#advance-telephone-reveal")
+
+    {:ok, bob_view, _html} =
+      live(build_conn(), ~p"/game/#{room_id}/telephone?resume_token=#{bob_token}")
+
+    assert has_element?(bob_view, "#waiting-for-reveal-host")
+    refute has_element?(bob_view, "#advance-telephone-reveal")
+  end
+
+  test "drawing deltas stay private and reconnect receives the current baseline", %{
+    conn: conn,
+    room_id: room_id
+  } do
+    {host_token, _} = join_connected(room_id, "Alice")
+    {bob_token, _} = join_connected(room_id, "Bob")
+    start_telephone(room_id, host_token, bob_token)
+    {:ok, host, _html} = live(conn, ~p"/game/#{room_id}/telephone?resume_token=#{host_token}")
+    assert_push_event(host, "drawing_state", %{events: []})
+
+    event = %{
+      "event_type" => "start",
+      "x" => 12,
+      "y" => 34,
+      "color" => "#000000",
+      "line_width" => 4
+    }
+
+    host |> element("#telephone-drawing-canvas") |> render_hook("draw_event", event)
+    _ = :sys.get_state(room_pid(room_id))
+
+    {:ok, duplicate, _html} =
+      live(build_conn(), ~p"/game/#{room_id}/telephone?resume_token=#{host_token}")
+
+    assert_push_event(duplicate, "drawing_state", %{events: [^event]})
+  end
+
+  test "revealed entries can be voted on and the host completes reveal to awards", %{
+    conn: conn,
+    room_id: room_id
+  } do
+    {host_token, _} = join_connected(room_id, "Alice")
+    {bob_token, _} = join_connected(room_id, "Bob")
+    start_telephone(room_id, host_token, bob_token)
+    {:ok, host, _html} = live(conn, ~p"/game/#{room_id}/telephone?resume_token=#{host_token}")
+
+    host |> element("#submit-telephone-drawing") |> render_click()
+    :ok = command_as(room_id, bob_token, :submit_drawing)
+    host |> form("#telephone-guess-form", %{"guess" => %{"text" => "moon"}}) |> render_submit()
+    :ok = command_as(room_id, bob_token, {:submit_guess, "cactus"})
+    host |> element("#advance-telephone-reveal") |> render_click()
+
+    {:ok, snapshot} = snapshot_as(room_id, host_token)
+    drawing = Enum.find(snapshot.reveal.chain.entries, &(&1.type == :drawing))
+    vote_id = "vote-worst_drawing-#{drawing.id}"
+    assert has_element?(host, "##{vote_id}")
+    host |> element("##{vote_id}") |> render_click()
+    assert has_element?(host, "##{vote_id}.bg-yellow-200")
+    assert has_element?(host, "##{vote_id} span", "1")
+
+    for _ <- 1..5 do
+      host |> element("#advance-telephone-reveal") |> render_click()
+    end
+
+    assert has_element?(host, "#telephone-awards")
+    assert has_element?(host, "#telephone-play-again")
+    assert has_element?(host, "#telephone-new-room")
+  end
+
+  test "Telephone URL redirects Scribble rooms safely and rejects a bad token", %{
+    conn: conn,
+    room_id: room_id
+  } do
+    {host_token, _} = join_connected(room_id, "Alice")
+    {_bob_token, _} = join_connected(room_id, "Bob")
+
+    assert {:error, {:live_redirect, %{to: scribble_path}}} =
+             live(conn, ~p"/game/#{room_id}/telephone?resume_token=#{host_token}")
+
+    assert scribble_path == "/game/#{room_id}?resume_token=#{host_token}"
+
+    assert {:error, {:live_redirect, %{to: "/"}}} =
+             live(build_conn(), ~p"/game/#{room_id}/telephone?resume_token=not-a-token")
+  end
+end


### PR DESCRIPTION
Telephone gives every player something to do each round and turns the chain reveal into the main shared payoff, providing a differentiated mode beyond classic drawing-and-guessing. The reveal is host-paced and includes voting and end-of-game awards so groups can enjoy each chain together.\n\nThis also adds constraint roulette as a lower-cost companion mode built on the classic loop. Telephone intentionally uses its own simultaneous chain-based lifecycle, including private prompt selection and drawing projections, rather than layering more state onto classic mode.