### PR TITLE
Preserve telephone drawings across interrupted submissions

### DIFF
--- a/lib/flamingo/game_modes/telephone.ex
+++ b/lib/flamingo/game_modes/telephone.ex
@@ -377,8 +377,10 @@ defmodule Flamingo.GameModes.Telephone do
   end
 
   defp contribution(%{phase: :telephone_draw} = state, actor) do
-    if MapSet.member?(state.submitted, actor),
-      do: DrawingShare.compact_ops(Map.get(state.current_drawings, actor, [])),
+    events = Map.get(state.current_drawings, actor, [])
+
+    if MapSet.member?(state.submitted, actor) or events != [],
+      do: DrawingShare.compact_ops(events),
       else: nil
   end
 

--- a/test/flamingo/game_modes/telephone_test.exs
+++ b/test/flamingo/game_modes/telephone_test.exs
@@ -141,6 +141,51 @@ defmodule Flamingo.GameModes.TelephoneTest do
     assert Enum.all?(reveal.chains, &(length(&1.entries) == 3))
   end
 
+  test "timeout and disconnect preserve drawings that already reached the server" do
+    {state, game_roster} = started(["a", "b"])
+
+    event = %{
+      "event_type" => "start",
+      "x" => 10,
+      "y" => 20,
+      "color" => "#000000",
+      "line_width" => 9
+    }
+
+    {:ok, %{state: state}} =
+      Telephone.command(state, "b", {:draw, event}, context(game_roster, "b"))
+
+    {:ok, %{state: state}} =
+      Telephone.command(state, "a", :submit_drawing, context(game_roster, "a"))
+
+    offline_roster = put_in(game_roster.players["b"].connected, false)
+
+    {:ok, %{state: disconnected}} =
+      Telephone.connection_changed(state, "b", :offline, context(offline_roster))
+
+    assert disconnected.phase == :telephone_guess
+
+    assert Telephone.view(disconnected, "a", offline_roster).assignment.source.value == [
+             ["p", "#000000", 9, [10, 20]]
+           ]
+
+    {state, game_roster} = started(["a", "b"])
+
+    {:ok, %{state: state}} =
+      Telephone.command(state, "b", {:draw, event}, context(game_roster, "b"))
+
+    {:ok, %{state: timed_out}} =
+      Telephone.timeout(state, :telephone_step, context(game_roster))
+
+    assert timed_out.phase == :telephone_guess
+
+    assert Telephone.view(timed_out, "a", game_roster).assignment.source.value == [
+             ["p", "#000000", 9, [10, 20]]
+           ]
+
+    assert Enum.at(timed_out.chains, 0).entries |> List.last() |> Map.fetch!(:value) == nil
+  end
+
   test "a transient fully-offline room does not skip a step" do
     {state, game_roster} = started(["a", "b"])
 


### PR DESCRIPTION
Telephone rounds could show a blank canvas when a player drew but disconnected or timed out before their Done action was recorded. The server had received the artwork, but the forced step transition treated the contribution as missing.

Already-received artwork now remains available to the next player, while players who sent no drawing data still produce an intentional missing link.