### PR TITLE
Rotate constraints and reveal hidden drawings

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -219,6 +219,10 @@
   opacity: 0;
 }
 
+#drawing-canvas[data-is-drawer="true"][data-phase="turn_reveal"] .roulette-hidden-canvas {
+  opacity: 1;
+}
+
 @keyframes roulette-canvas-rotate {
   0%, 100% { transform: rotate(-5deg) scale(0.96); }
   50% { transform: rotate(5deg) scale(0.96); }

--- a/lib/flamingo/game_modes/scribble.ex
+++ b/lib/flamingo/game_modes/scribble.ex
@@ -21,6 +21,7 @@ defmodule Flamingo.GameModes.Scribble do
       include_default_words: false,
       game_variant: :classic,
       constraint: nil,
+      remaining_constraints: %{},
       drawer_id: nil,
       current_round: 0,
       drawn_this_round: MapSet.new(),
@@ -64,7 +65,8 @@ defmodule Flamingo.GameModes.Scribble do
       | participants: Map.delete(state.participants, seat_id),
         scores: Map.delete(state.scores, seat_id),
         correct_guesses: Map.delete(state.correct_guesses, seat_id),
-        score_gains: Map.delete(state.score_gains, seat_id)
+        score_gains: Map.delete(state.score_gains, seat_id),
+        remaining_constraints: Map.delete(state.remaining_constraints, seat_id)
     }
 
     {feed, _} = Feed.player_left(state.feed, seat_id, removed.name)
@@ -114,6 +116,7 @@ defmodule Flamingo.GameModes.Scribble do
           include_default_words: defaults,
           game_variant: game_variant,
           constraint: nil,
+          remaining_constraints: %{},
           participants: participants,
           drawer_id: Enum.find(roster.player_order, &active?(participants, &1)),
           current_round: 0,
@@ -284,12 +287,7 @@ defmodule Flamingo.GameModes.Scribble do
     choices =
       context.word_choices.(3, state.used_words, state.custom_words, state.include_default_words)
 
-    constraint =
-      if state.game_variant == :constraint_roulette,
-        do: choose(context, @constraints),
-        else: nil
-
-    state = %{state | constraint: constraint}
+    state = choose_constraint(state, context)
 
     if choices == [],
       do: game_ended(state, context.roster),
@@ -468,6 +466,24 @@ defmodule Flamingo.GameModes.Scribble do
   defp online?(roster, id), do: roster.players[id].connected
   defp online_count(roster), do: Enum.count(roster.players, fn {_, p} -> p.connected end)
   defp choose(context, candidates), do: context.select_candidate.(candidates)
+
+  defp choose_constraint(%{game_variant: :constraint_roulette} = state, context) do
+    remaining = Map.get(state.remaining_constraints, state.drawer_id, @constraints)
+    constraint = choose(context, remaining)
+
+    %{
+      state
+      | constraint: constraint,
+        remaining_constraints:
+          Map.put(
+            state.remaining_constraints,
+            state.drawer_id,
+            List.delete(remaining, constraint)
+          )
+    }
+  end
+
+  defp choose_constraint(state, _context), do: %{state | constraint: nil}
 
   defp constraint_event_allowed?(%{constraint: :single_stroke} = state, event) do
     type = event["event_type"]

--- a/lib/flamingo_web/live/scribble_live.ex
+++ b/lib/flamingo_web/live/scribble_live.ex
@@ -413,8 +413,24 @@ defmodule FlamingoWeb.ScribbleLive do
                       </span>
                     </div>
                     <%= if @phase == :turn_reveal do %>
-                      <div class="absolute inset-x-0 top-0 z-10 m-[2px] flex h-[500px] items-center justify-center bg-white/75 text-center backdrop-blur-[2px]">
-                        <div class="flex w-full flex-col items-center gap-4 px-6">
+                      <div
+                        id="turn-reveal-overlay"
+                        class={[
+                          "absolute inset-x-0 top-0 z-10 m-[2px] flex h-[500px] items-center justify-center text-center",
+                          if(
+                            @constraint == :hidden_canvas and @player_id == @drawer_id and
+                              @participation == :active,
+                            do: "bg-white/20",
+                            else: "bg-white/75 backdrop-blur-[2px]"
+                          )
+                        ]}
+                      >
+                        <div class={[
+                          "flex w-full flex-col items-center gap-4 px-6",
+                          (@constraint == :hidden_canvas and @player_id == @drawer_id and
+                             @participation == :active) &&
+                            "mx-8 w-auto border-2 border-border bg-white/90 py-4 shadow-shadow"
+                        ]}>
                           <div>
                             <p class="text-xl font-black">The word was</p>
                             <p class="font-hero text-5xl leading-none font-black text-pink-400">
@@ -470,6 +486,7 @@ defmodule FlamingoWeb.ScribbleLive do
                         to_string(@player_id == @drawer_id and @participation == :active)
                       }
                       data-constraint={@constraint}
+                      data-phase={@phase}
                       class="flex flex-col gap-2"
                     >
                       <.box class="bg-white p-0">

--- a/test/flamingo/game_modes/scribble_test.exs
+++ b/test/flamingo/game_modes/scribble_test.exs
@@ -88,19 +88,28 @@ defmodule Flamingo.GameModes.ScribbleTest do
     assert restarted.used_words == MapSet.new()
   end
 
-  test "constraint roulette selects and projects a constraint for each turn" do
+  test "constraint roulette rotates through every constraint for each drawer" do
     pick_last = fn candidates -> List.last(candidates) end
+    game_context = context(select_candidate: pick_last)
 
     {:ok, %{state: roulette}} =
       Scribble.start(
         admitted(),
-        %{round_count: 1, game_variant: :constraint_roulette},
-        context(select_candidate: pick_last)
+        %{round_count: 2, game_variant: :constraint_roulette},
+        game_context
       )
 
     assert roulette.constraint == :mirror
     assert Scribble.view(roulette, "b", roster()).constraint == :mirror
     assert Scribble.view(roulette, "b", roster()).game_variant == :constraint_roulette
+
+    {%{state: roulette}, _word} = complete_turn(roulette, game_context)
+    assert roulette.drawer_id == "b"
+    assert roulette.constraint == :mirror
+
+    {%{state: roulette}, _word} = complete_turn(roulette, game_context)
+    assert roulette.drawer_id == "a"
+    assert roulette.constraint == :rotating_canvas
 
     {:ok, %{state: classic}} = Scribble.start(admitted(), %{round_count: 1}, context())
     assert classic.constraint == nil

--- a/test/flamingo_web/live/scribble_live_test.exs
+++ b/test/flamingo_web/live/scribble_live_test.exs
@@ -448,6 +448,40 @@ defmodule FlamingoWeb.ScribbleLiveTest do
     refute has_element?(spectator_view, "#guess-form")
   end
 
+  test "hidden canvas is revealed to the drawer during turn reveal", %{
+    conn: conn,
+    room_id: room_id
+  } do
+    {:ok, drawer_token, _drawer_snapshot} = join_connected(room_id, "Alice")
+    {:ok, guesser_token, _guesser_snapshot} = join_connected(room_id, "Bob")
+
+    :ok =
+      start_game_as(room_id, drawer_token, %{
+        game_variant: :constraint_roulette,
+        custom_words: ["secret", "other", "third"]
+      })
+
+    {:ok, state} = room_snapshot(room_id)
+    :sys.replace_state(room_pid(room_id), &put_in(&1.game.constraint, :hidden_canvas))
+
+    {:ok, drawer_view, _html} =
+      live(conn, ~p"/game/#{room_id}?resume_token=#{drawer_token}")
+
+    :ok = select_word_as(room_id, drawer_token, List.first(state.word_choices))
+
+    assert has_element?(
+             drawer_view,
+             "#drawing-canvas[data-is-drawer='true'][data-constraint='hidden_canvas'][data-phase='playing']"
+           )
+
+    assert :correct = guess_as(room_id, guesser_token, List.first(state.word_choices))
+
+    assert has_element?(
+             drawer_view,
+             "#drawing-canvas[data-is-drawer='true'][data-constraint='hidden_canvas'][data-phase='turn_reveal']"
+           )
+  end
+
   test "a late joiner spectates until the next turn", %{conn: conn, room_id: room_id} do
     {:ok, drawer_token, %{viewer_id: drawer}} = join_connected(room_id, "Alice")
     {:ok, guesser_token, %{viewer_id: guesser}} = join_connected(room_id, "Bob")


### PR DESCRIPTION
Constraint roulette could repeatedly assign the same challenge to a player, making multi-round games feel less varied. Give each drawer an independent constraint bag so they see every challenge before any repeat.\n\nHidden-canvas drawers also had no chance to see what they produced. During the existing five-second turn reveal, show their canvas behind a lighter results treatment while preserving the normal reveal for everyone else.