### PR TITLE
Fix telephone game flow and finale

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -219,6 +219,50 @@
   opacity: 0;
 }
 
+@keyframes telephone-reveal-pop {
+  0% { opacity: 0; transform: translateY(24px) scale(0.96) rotate(-1deg); }
+  70% { transform: translateY(-3px) scale(1.01) rotate(0.5deg); }
+  100% { opacity: 1; transform: translateY(0) scale(1) rotate(0); }
+}
+
+@keyframes telephone-float {
+  0%, 100% { transform: translateY(0) rotate(-6deg); }
+  50% { transform: translateY(-10px) rotate(6deg); }
+}
+
+@keyframes telephone-award-arrive {
+  0% { opacity: 0; transform: translateY(32px) rotate(-2deg); }
+  100% { opacity: 1; transform: translateY(0) rotate(0); }
+}
+
+.telephone-reveal-current {
+  animation: telephone-reveal-pop 520ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.telephone-float {
+  animation: telephone-float 2.8s ease-in-out infinite;
+}
+
+.telephone-award-card {
+  animation: telephone-award-arrive 480ms ease-out backwards;
+}
+
+.telephone-award-card:nth-child(2) {
+  animation-delay: 140ms;
+}
+
+.telephone-award-card:nth-child(3) {
+  animation-delay: 280ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .telephone-reveal-current,
+  .telephone-float,
+  .telephone-award-card {
+    animation: none;
+  }
+}
+
 @keyframes roulette-canvas-rotate {
   0%, 100% { transform: rotate(-5deg) scale(0.96); }
   50% { transform: rotate(5deg) scale(0.96); }

--- a/lib/flamingo/game_modes/telephone.ex
+++ b/lib/flamingo/game_modes/telephone.ex
@@ -18,7 +18,7 @@ defmodule Flamingo.GameModes.Telephone do
       prompt_choices: %{},
       selected_prompts: %{},
       chains: [],
-      step_offsets: [],
+      pass_order: [],
       current_step: nil,
       current_drawings: %{},
       guesses: %{},
@@ -84,7 +84,7 @@ defmodule Flamingo.GameModes.Telephone do
         |> Enum.with_index()
         |> Map.new(fn {id, index} -> {id, rotated_choices(prompts, index)} end)
 
-      step_offsets = [0 | random_order(Enum.to_list(1..(length(order) - 1)), context)]
+      pass_order = random_order(order, context)
 
       state = %{
         state
@@ -99,11 +99,13 @@ defmodule Flamingo.GameModes.Telephone do
           prompt_choices: prompt_choices,
           selected_prompts: %{},
           chains: [],
-          step_offsets: step_offsets,
+          pass_order: pass_order,
           current_step: nil,
           current_drawings: %{},
           guesses: %{},
           submitted: MapSet.new(),
+          reveal_chain_index: nil,
+          reveal_entry_index: nil,
           votes: %{},
           awards: %{},
           final_result: nil
@@ -188,6 +190,14 @@ defmodule Flamingo.GameModes.Telephone do
   end
 
   def command(_state, _actor, {:submit_guess, _}, _context), do: {:error, :invalid_guess}
+
+  def command(state, actor, :start_reveal, _context) do
+    cond do
+      state.phase != :telephone_return -> {:error, :not_return}
+      actor != state.host_id -> {:error, :not_host}
+      true -> ok(enter_reveal(state))
+    end
+  end
 
   def command(state, actor, :advance_reveal, _context) do
     cond do
@@ -334,9 +344,8 @@ defmodule Flamingo.GameModes.Telephone do
     n = length(state.player_order)
 
     chains =
-      Enum.with_index(state.player_order)
-      |> Enum.reduce(state.chains, fn {actor, actor_index}, chains ->
-        chain_index = chain_index(state, actor_index)
+      Enum.reduce(state.player_order, state.chains, fn actor, chains ->
+        chain_index = chain_index(state, actor)
         value = contribution(state, actor)
         type = if state.phase == :telephone_draw, do: :drawing, else: :guess
 
@@ -352,13 +361,13 @@ defmodule Flamingo.GameModes.Telephone do
     if next >= n do
       {%{
          state
-         | phase: :telephone_reveal,
+         | phase: :telephone_return,
            chains: chains,
            current_step: nil,
            submitted: MapSet.new(),
            current_drawings: %{},
-           reveal_chain_index: 0,
-           reveal_entry_index: 0
+           reveal_chain_index: nil,
+           reveal_entry_index: nil
        }, [:cancel_phase_timeout, :cancel_hint_timeout]}
     else
       phase = if rem(next, 2) == 0, do: :telephone_draw, else: :telephone_guess
@@ -392,13 +401,12 @@ defmodule Flamingo.GameModes.Telephone do
     do: if(MapSet.member?(state.submitted, actor), do: Map.get(state.guesses, actor), else: nil)
 
   defp assignment(state, actor) when state.phase in [:telephone_draw, :telephone_guess] do
-    case Enum.find_index(state.player_order, &(&1 == actor)) do
+    case chain_index(state, actor) do
       nil ->
         nil
 
-      index ->
-        chain = Enum.at(state.chains, chain_index(state, index))
-
+      chain_index ->
+        chain = Enum.at(state.chains, chain_index)
         source = List.last(chain.entries)
 
         %{
@@ -409,11 +417,33 @@ defmodule Flamingo.GameModes.Telephone do
     end
   end
 
+  defp assignment(%{phase: :telephone_return} = state, actor) do
+    case Enum.find(state.chains, &(&1.origin_player_id == actor)) do
+      nil ->
+        nil
+
+      chain ->
+        %{
+          chain_id: chain.id,
+          type: :return,
+          origin: List.first(chain.entries),
+          source: List.last(chain.entries)
+        }
+    end
+  end
+
   defp assignment(_state, _actor), do: nil
 
-  defp chain_index(state, player_index) do
-    offset = Enum.at(state.step_offsets, state.current_step)
-    Integer.mod(player_index - offset, length(state.player_order))
+  defp chain_index(state, actor) do
+    case Enum.find_index(state.pass_order, &(&1 == actor)) do
+      nil ->
+        nil
+
+      actor_index ->
+        origin_index = Integer.mod(actor_index - state.current_step, length(state.pass_order))
+        origin = Enum.at(state.pass_order, origin_index)
+        Enum.find_index(state.player_order, &(&1 == origin))
+    end
   end
 
   defp entry(chain, index, type, player, value),
@@ -453,6 +483,15 @@ defmodule Flamingo.GameModes.Telephone do
   defp random_order(remaining, context) do
     selected = context.select_candidate.(remaining)
     [selected | random_order(List.delete(remaining, selected), context)]
+  end
+
+  defp enter_reveal(state) do
+    %{
+      state
+      | phase: :telephone_reveal,
+        reveal_chain_index: 0,
+        reveal_entry_index: 0
+    }
   end
 
   defp advance_reveal(state) do

--- a/lib/flamingo/game_modes/telephone.ex
+++ b/lib/flamingo/game_modes/telephone.ex
@@ -18,6 +18,7 @@ defmodule Flamingo.GameModes.Telephone do
       prompt_choices: %{},
       selected_prompts: %{},
       chains: [],
+      step_offsets: [],
       current_step: nil,
       current_drawings: %{},
       guesses: %{},
@@ -83,6 +84,8 @@ defmodule Flamingo.GameModes.Telephone do
         |> Enum.with_index()
         |> Map.new(fn {id, index} -> {id, rotated_choices(prompts, index)} end)
 
+      step_offsets = [0 | random_order(Enum.to_list(1..(length(order) - 1)), context)]
+
       state = %{
         state
         | phase: :telephone_prompt,
@@ -96,6 +99,7 @@ defmodule Flamingo.GameModes.Telephone do
           prompt_choices: prompt_choices,
           selected_prompts: %{},
           chains: [],
+          step_offsets: step_offsets,
           current_step: nil,
           current_drawings: %{},
           guesses: %{},
@@ -332,7 +336,7 @@ defmodule Flamingo.GameModes.Telephone do
     chains =
       Enum.with_index(state.player_order)
       |> Enum.reduce(state.chains, fn {actor, actor_index}, chains ->
-        chain_index = Integer.mod(actor_index - state.current_step, n)
+        chain_index = chain_index(state, actor_index)
         value = contribution(state, actor)
         type = if state.phase == :telephone_draw, do: :drawing, else: :guess
 
@@ -393,11 +397,7 @@ defmodule Flamingo.GameModes.Telephone do
         nil
 
       index ->
-        chain =
-          Enum.at(
-            state.chains,
-            Integer.mod(index - state.current_step, length(state.player_order))
-          )
+        chain = Enum.at(state.chains, chain_index(state, index))
 
         source = List.last(chain.entries)
 
@@ -410,6 +410,11 @@ defmodule Flamingo.GameModes.Telephone do
   end
 
   defp assignment(_state, _actor), do: nil
+
+  defp chain_index(state, player_index) do
+    offset = Enum.at(state.step_offsets, state.current_step)
+    Integer.mod(player_index - offset, length(state.player_order))
+  end
 
   defp entry(chain, index, type, player, value),
     do: %{
@@ -443,6 +448,13 @@ defmodule Flamingo.GameModes.Telephone do
     Enum.take(after_index ++ before, 3)
   end
 
+  defp random_order([], _context), do: []
+
+  defp random_order(remaining, context) do
+    selected = context.select_candidate.(remaining)
+    [selected | random_order(List.delete(remaining, selected), context)]
+  end
+
   defp advance_reveal(state) do
     chain = Enum.at(state.chains, state.reveal_chain_index)
 
@@ -463,6 +475,8 @@ defmodule Flamingo.GameModes.Telephone do
     %{
       chain_index: state.reveal_chain_index,
       entry_index: state.reveal_entry_index,
+      chain_count: length(state.chains),
+      entry_count: length(chain.entries),
       chain: %{
         chain
         | entries:

--- a/lib/flamingo_web/components/telephone_components.ex
+++ b/lib/flamingo_web/components/telephone_components.ex
@@ -179,18 +179,86 @@ defmodule FlamingoWeb.TelephoneComponents do
   def reveal_phase(assigns) do
     chain = assigns.reveal && Map.get(assigns.reveal, :chain)
     entries = if chain, do: Map.get(chain, :entries, []), else: []
-    assigns = assign(assigns, chain: chain, entries: entries, categories: @categories)
+
+    assigns =
+      assign(assigns,
+        chain: chain,
+        entries: entries,
+        current_entry: List.last(entries),
+        chain_count: Map.get(assigns.reveal || %{}, :chain_count, 0),
+        entry_count: Map.get(assigns.reveal || %{}, :entry_count, 0),
+        categories: @categories
+      )
 
     ~H"""
-    <section id="telephone-reveal-phase" class="space-y-5">
-      <.box class="bg-purple-100 p-5 text-center">
-        <p id="reveal-progress" class="text-sm font-bold tracking-wider uppercase">
-          Chain {number(@reveal, :chain_index)} · Link {number(@reveal, :entry_index)}
-        </p>
-        <h2 class="font-hero text-3xl font-black text-purple-700 sm:text-5xl">The grand reveal</h2>
-        <p class="mt-2">
-          Started by <strong>{player_name(@players, @chain && @chain.origin_player_id)}</strong>
-        </p>
+    <section id="telephone-reveal-phase" class="space-y-6 pb-6">
+      <.box class="relative overflow-hidden bg-purple-100 p-5 text-center sm:p-8">
+        <div aria-hidden="true" class="pointer-events-none absolute inset-0 overflow-hidden">
+          <.icon
+            name={:sparkles}
+            class="telephone-float absolute -top-3 left-[7%] h-16 w-16 rotate-[-12deg] text-yellow-500 opacity-60"
+          />
+          <.icon
+            name={:shuffle}
+            class="telephone-float absolute top-5 right-[7%] h-14 w-14 rotate-12 text-pink-500 opacity-50 [animation-delay:350ms]"
+          />
+        </div>
+        <div class="relative">
+          <p id="reveal-progress" class="text-sm font-black tracking-wider uppercase">
+            Chain {number(@reveal, :chain_index)} of {@chain_count} · Link {number(
+              @reveal,
+              :entry_index
+            )} of {@entry_count}
+          </p>
+          <h2 class="mt-1 font-hero text-4xl font-black text-purple-700 sm:text-6xl">
+            Watch the story unravel
+          </h2>
+          <p class="mx-auto mt-2 max-w-xl text-base sm:text-lg">
+            It started with <strong>{player_name(@players, @chain && @chain.origin_player_id)}</strong>.
+            Now every link gets its moment.
+          </p>
+
+          <div class="mx-auto mt-6 grid max-w-3xl gap-4 sm:grid-cols-2">
+            <div>
+              <p class="mb-2 text-xs font-black tracking-widest text-purple-700 uppercase">
+                Stories
+              </p>
+              <div
+                id="reveal-chain-progress"
+                class="flex items-center justify-center gap-1.5"
+                aria-label="Chain reveal progress"
+              >
+                <span
+                  :for={index <- progress_indices(@chain_count)}
+                  data-state={progress_state(index, Map.get(@reveal || %{}, :chain_index))}
+                  class={[
+                    "h-3 flex-1 border-2 border-border transition-all duration-300",
+                    progress_class(index, Map.get(@reveal || %{}, :chain_index))
+                  ]}
+                >
+                </span>
+              </div>
+            </div>
+            <div>
+              <p class="mb-2 text-xs font-black tracking-widest text-pink-700 uppercase">Links</p>
+              <div
+                id="reveal-link-progress"
+                class="flex items-center justify-center gap-1.5"
+                aria-label="Current chain progress"
+              >
+                <span
+                  :for={index <- progress_indices(@entry_count)}
+                  data-state={progress_state(index, Map.get(@reveal || %{}, :entry_index))}
+                  class={[
+                    "h-3 flex-1 border-2 border-border transition-all duration-300",
+                    progress_class(index, Map.get(@reveal || %{}, :entry_index))
+                  ]}
+                >
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
       </.box>
       <div
         id="revealed-entries"
@@ -203,22 +271,44 @@ defmodule FlamingoWeb.TelephoneComponents do
         <article
           :for={entry <- @entries}
           id={"telephone-entry-#{entry.id}"}
-          class="animate-in fade-in zoom-in-95 duration-500 rounded-base border-2 border-border bg-white p-4 shadow-shadow transition hover:-translate-y-1"
+          data-current={to_string(current_entry?(entry, @current_entry))}
+          data-entry-type={entry.type}
+          class={[
+            "rounded-base border-2 border-border p-4 shadow-shadow transition-all duration-300",
+            current_entry?(entry, @current_entry) &&
+              "telephone-reveal-current bg-yellow-50 p-5 md:col-span-2 sm:p-7",
+            not current_entry?(entry, @current_entry) &&
+              "bg-white opacity-75 hover:-translate-y-1 hover:opacity-100"
+          ]}
         >
-          <div class="mb-3 flex items-center gap-2">
-            <.flamingo_avatar
-              avatar={player_avatar(@players, entry.player_id || @chain.origin_player_id)}
-              class="h-10 w-10"
-              label={
-                "#{player_name(@players, entry.player_id || @chain.origin_player_id)}'s avatar"
-              }
-            />
-            <div>
-              <p class="font-bold">
-                {player_name(@players, entry.player_id || @chain.origin_player_id)}
-              </p>
-              <p class="text-xs font-bold text-gray-500 uppercase">{entry_label(entry)}</p>
+          <div class="mb-3 flex items-center justify-between gap-3">
+            <div class="flex items-center gap-2">
+              <.flamingo_avatar
+                avatar={player_avatar(@players, entry.player_id || @chain.origin_player_id)}
+                class={[
+                  "h-10 w-10",
+                  current_entry?(entry, @current_entry) && "sm:h-14 sm:w-14"
+                ]}
+                label={
+                  "#{player_name(@players, entry.player_id || @chain.origin_player_id)}'s avatar"
+                }
+              />
+              <div>
+                <p class={[
+                  "font-bold",
+                  current_entry?(entry, @current_entry) && "text-lg sm:text-xl"
+                ]}>
+                  {player_name(@players, entry.player_id || @chain.origin_player_id)}
+                </p>
+                <p class="text-xs font-bold text-gray-500 uppercase">{entry_label(entry)}</p>
+              </div>
             </div>
+            <span
+              :if={current_entry?(entry, @current_entry)}
+              class="rotate-2 border-2 border-border bg-pink-300 px-3 py-1 font-hero text-sm font-black tracking-wider uppercase shadow-shadow"
+            >
+              Latest twist
+            </span>
           </div>
           <%= if entry.type == :drawing do %>
             <div
@@ -228,8 +318,9 @@ defmodule FlamingoWeb.TelephoneComponents do
               data-is-drawer="false"
               data-final-drawing-replay="true"
               data-final-drawing-events={Jason.encode!(entry.value || [])}
+              class={current_entry?(entry, @current_entry) && "mx-auto max-w-4xl"}
             >
-              <div class="relative aspect-[7/5] w-full bg-white">
+              <div class="relative aspect-[7/5] w-full border-2 border-border bg-white">
                 <canvas width="700" height="500" class="absolute inset-0 h-full w-full"></canvas>
                 <.drawing_fallback ops={entry.value || []} />
               </div>
@@ -237,9 +328,12 @@ defmodule FlamingoWeb.TelephoneComponents do
           <% else %>
             <p
               id={"reveal-text-#{entry.id}"}
-              class="flex min-h-36 items-center justify-center p-5 text-center font-hero text-3xl font-black text-pink-500"
+              class={[
+                "flex min-h-36 items-center justify-center p-5 text-center font-hero text-3xl font-black text-pink-500",
+                current_entry?(entry, @current_entry) && "sm:min-h-48 sm:text-5xl"
+              ]}
             >
-              {present_text(entry.value)}
+              “{present_text(entry.value)}”
             </p>
           <% end %>
           <div :if={@participation == :active} class="mt-4 flex flex-wrap gap-2">
@@ -259,17 +353,26 @@ defmodule FlamingoWeb.TelephoneComponents do
           </div>
         </article>
       </div>
-      <div id="reveal-controls" class="text-center">
+      <div
+        id="reveal-controls"
+        class="sticky bottom-3 z-30 mx-auto max-w-3xl border-2 border-border bg-white/95 p-4 text-center shadow-shadow backdrop-blur-sm sm:p-5"
+      >
+        <p id="reveal-next-hint" class="mb-3 text-sm font-bold text-gray-600">
+          {reveal_hint(@reveal, @current_entry)}
+        </p>
         <.button
           :if={@viewer_id == @host_id}
           id="advance-telephone-reveal"
           phx-click="advance_reveal"
-          class="px-8 py-3 text-lg font-black"
+          class="min-w-64 justify-center px-8 py-3 text-lg font-black"
         >
-          Next reveal <.icon name={:arrow_right} class="ml-2 h-5 w-5" />
+          {reveal_button_label(@reveal, @current_entry)}<.icon
+            name={:arrow_right}
+            class="ml-2 h-5 w-5"
+          />
         </.button>
         <p :if={@viewer_id != @host_id} id="waiting-for-reveal-host" class="font-bold text-gray-600">
-          The host is choosing the dramatic moment…
+          The host is choosing the dramatic moment… hold your breath.
         </p>
       </div>
     </section>
@@ -284,34 +387,65 @@ defmodule FlamingoWeb.TelephoneComponents do
     assigns = assign(assigns, categories: @categories)
 
     ~H"""
-    <section id="telephone-awards" class="space-y-6 text-center">
-      <div>
-        <p class="font-hero text-lg font-black text-purple-600">FIN</p>
-        <h2 class="text-4xl font-black sm:text-6xl">Telephone legends</h2>
+    <section id="telephone-awards" class="relative space-y-7 overflow-hidden pb-8 text-center">
+      <div aria-hidden="true" class="pointer-events-none absolute inset-0">
+        <.icon
+          name={:sparkles}
+          class="telephone-float absolute top-6 left-[4%] h-16 w-16 -rotate-12 text-yellow-500"
+        />
+        <.icon
+          name={:sparkles}
+          class="telephone-float absolute top-24 right-[3%] h-20 w-20 rotate-12 text-pink-500 [animation-delay:500ms]"
+        />
       </div>
-      <div class="grid gap-4 md:grid-cols-3">
+      <div id="telephone-finale-banner" class="relative">
+        <.box class="bg-purple-600 p-7 text-white sm:p-10">
+          <div class="relative">
+            <p class="font-hero text-sm font-black tracking-[0.35em] text-yellow-200 uppercase">
+              Every chain survived
+            </p>
+            <h2 class="mt-2 font-hero text-5xl font-black sm:text-7xl">Telephone legends!</h2>
+            <p class="mx-auto mt-3 max-w-2xl text-lg font-bold text-purple-50 sm:text-xl">
+              {@players |> map_size()} players turned simple prompts into absolute nonsense. Time to
+              celebrate the links nobody saw coming.
+            </p>
+          </div>
+        </.box>
+      </div>
+      <div id="telephone-award-cards" class="relative grid gap-5 md:grid-cols-3">
         <.box
           :for={{category, label, icon} <- @categories}
-          class="bg-white p-6 transition hover:-translate-y-1"
+          class={[
+            "telephone-award-card p-6 transition hover:-translate-y-2",
+            award_card_class(category)
+          ]}
         >
-          <.icon name={icon} class="mx-auto h-9 w-9 text-pink-500" />
-          <h3 class="mt-2 text-xl font-black">{label}</h3>
+          <div class="mx-auto flex h-16 w-16 rotate-3 items-center justify-center rounded-full border-2 border-border bg-white shadow-shadow">
+            <.icon name={icon} class="h-9 w-9 text-purple-700" />
+          </div>
+          <p class="mt-5 text-xs font-black tracking-[0.2em] text-purple-700 uppercase">
+            The award for
+          </p>
+          <h3 class="mt-1 font-hero text-2xl font-black">{label}</h3>
           <%= if award = Map.get(@awards, category) do %>
             <.flamingo_avatar
               avatar={player_avatar(@players, award.player_id)}
-              class="mx-auto mt-4 h-24 w-24"
+              class="mx-auto mt-5 h-24 w-24"
               label={"#{player_name(@players, award.player_id)}'s avatar"}
             />
-            <p class="text-2xl font-black">{player_name(@players, award.player_id)}</p>
-            <p class="text-sm text-gray-600">
+            <p class="mt-2 text-2xl font-black">{player_name(@players, award.player_id)}</p>
+            <p class="mt-2 border-y-2 border-border/20 py-3 font-hero text-lg font-black text-pink-700">
+              {award_summary(award)}
+            </p>
+            <p class="mt-3 text-sm font-bold text-gray-600">
               {award.votes} {if(award.votes == 1, do: "vote", else: "votes")}
             </p>
           <% else %>
-            <p class="mt-8 text-gray-500">No votes this time—every link is a winner.</p>
+            <p class="mt-8 text-gray-600">No votes this time—chaos made winners of everyone.</p>
           <% end %>
         </.box>
       </div>
-      <div class="flex flex-wrap justify-center gap-3">
+      <div class="relative flex flex-wrap justify-center gap-3 border-2 border-border bg-white p-5 shadow-shadow">
         <.button
           :if={@host?}
           id="telephone-play-again"
@@ -426,6 +560,57 @@ defmodule FlamingoWeb.TelephoneComponents do
 
   defp number(map, key),
     do: if(is_integer(Map.get(map, key)), do: Map.get(map, key) + 1, else: "–")
+
+  defp progress_indices(count) when count > 0, do: 0..(count - 1)
+  defp progress_indices(_count), do: []
+
+  defp progress_state(index, current) when index < current, do: "complete"
+  defp progress_state(index, index), do: "current"
+  defp progress_state(_index, _current), do: "upcoming"
+
+  defp progress_class(index, current) when index < current, do: "bg-purple-500"
+  defp progress_class(index, index), do: "scale-y-150 bg-yellow-300"
+  defp progress_class(_index, _current), do: "bg-white"
+
+  defp current_entry?(%{id: id}, %{id: id}), do: true
+  defp current_entry?(_entry, _current), do: false
+
+  defp reveal_button_label(reveal, entry) do
+    cond do
+      reveal.entry_index + 1 < reveal.entry_count -> next_link_label(entry)
+      reveal.chain_index + 1 < reveal.chain_count -> "Unwrap the next chain"
+      true -> "Crown the legends"
+    end
+  end
+
+  defp next_link_label(%{type: :prompt}), do: "Reveal the first drawing"
+  defp next_link_label(%{type: :drawing}), do: "Reveal what they guessed"
+  defp next_link_label(_entry), do: "Reveal the next drawing"
+
+  defp reveal_hint(reveal, _entry)
+       when reveal.entry_index + 1 == reveal.entry_count and
+              reveal.chain_index + 1 == reveal.chain_count,
+       do: "That’s every last twist. Make sure your votes are in."
+
+  defp reveal_hint(reveal, _entry) when reveal.entry_index + 1 == reveal.entry_count,
+    do: "This story is complete. Another chain is waiting backstage."
+
+  defp reveal_hint(_reveal, %{type: :prompt}),
+    do: "The innocent beginning—before the first artist got involved."
+
+  defp reveal_hint(_reveal, %{type: :drawing}),
+    do: "A picture is worth a thousand words. The next player only got one guess."
+
+  defp reveal_hint(_reveal, _entry),
+    do: "That guess became somebody else’s drawing prompt. What could go wrong?"
+
+  defp award_card_class(:derailment), do: "bg-purple-100"
+  defp award_card_class(:best_save), do: "bg-green-100"
+  defp award_card_class(:worst_drawing), do: "bg-yellow-100"
+
+  defp award_summary(%{entry: %{type: :guess, value: value}}), do: "“#{present_text(value)}”"
+  defp award_summary(%{entry: %{type: :drawing}}), do: "A masterpiece beyond words"
+  defp award_summary(_award), do: "An unforgettable link"
 
   defp entry_label(%{type: :prompt}), do: "Original prompt"
   defp entry_label(%{type: :drawing}), do: "Drawing"

--- a/lib/flamingo_web/components/telephone_components.ex
+++ b/lib/flamingo_web/components/telephone_components.ex
@@ -168,6 +168,137 @@ defmodule FlamingoWeb.TelephoneComponents do
     """
   end
 
+  attr :assignment, :map, default: nil
+  attr :players, :map, required: true
+  attr :viewer_id, :any, required: true
+  attr :host_id, :any, required: true
+
+  def return_phase(assigns) do
+    assigns =
+      assign(assigns,
+        original_entry: assigns.assignment && Map.get(assigns.assignment, :origin),
+        final_entry: assigns.assignment && Map.get(assigns.assignment, :source)
+      )
+
+    ~H"""
+    <section id="telephone-return-phase" class="mx-auto w-full max-w-5xl space-y-6 pb-8">
+      <.box class="relative overflow-hidden bg-purple-600 p-6 text-center text-white sm:p-10">
+        <div aria-hidden="true" class="pointer-events-none absolute inset-0 overflow-hidden">
+          <.icon
+            name={:sparkles}
+            class="telephone-float absolute top-3 left-[6%] h-16 w-16 text-yellow-300 opacity-70"
+          />
+          <.icon
+            name={:rotate_cw}
+            class="telephone-float absolute top-4 right-[7%] h-14 w-14 text-pink-200 opacity-60 [animation-delay:400ms]"
+          />
+        </div>
+        <div class="relative">
+          <p class="text-sm font-black tracking-[0.25em] text-yellow-200 uppercase">
+            Full circle
+          </p>
+          <h2 class="mt-2 font-hero text-4xl font-black sm:text-6xl">Your chain made it home</h2>
+          <p class="mx-auto mt-3 max-w-2xl text-lg font-bold text-purple-50">
+            Here’s your private first-and-final look. The twists in the middle stay secret until the
+            host starts the reveal.
+          </p>
+        </div>
+      </.box>
+
+      <div
+        :if={@assignment}
+        id="telephone-return-comparison"
+        class="grid items-stretch gap-5 md:grid-cols-[1fr_auto_1fr]"
+      >
+        <.box class="bg-white p-5 sm:p-7">
+          <p class="text-xs font-black tracking-widest text-purple-700 uppercase">Where it started</p>
+          <p
+            id="telephone-return-original"
+            class="flex min-h-44 items-center justify-center p-4 text-center font-hero text-3xl font-black text-purple-700 sm:text-4xl"
+          >
+            “{present_text(@original_entry && @original_entry.value)}”
+          </p>
+        </.box>
+
+        <div class="flex items-center justify-center" aria-hidden="true">
+          <div class="flex h-14 w-14 rotate-3 items-center justify-center rounded-full border-2 border-border bg-yellow-300 shadow-shadow">
+            <.icon name={:arrow_right} class="hidden h-7 w-7 md:block" />
+            <.icon name={:arrow_down} class="h-7 w-7 md:hidden" />
+          </div>
+        </div>
+
+        <.box class="telephone-reveal-current bg-yellow-50 p-5 sm:p-7">
+          <div class="flex items-center justify-between gap-3">
+            <div>
+              <p class="text-xs font-black tracking-widest text-pink-700 uppercase">
+                Where it landed
+              </p>
+              <p class="mt-1 font-bold">
+                Final link by {player_name(@players, @final_entry && @final_entry.player_id)}
+              </p>
+            </div>
+            <span class="rotate-2 border-2 border-border bg-pink-300 px-3 py-1 text-xs font-black uppercase shadow-shadow">
+              Just for you
+            </span>
+          </div>
+
+          <%= if @final_entry && @final_entry.type == :drawing do %>
+            <div
+              id="telephone-return-drawing"
+              phx-hook="DrawingCanvas"
+              phx-update="ignore"
+              data-is-drawer="false"
+              data-final-drawing-replay="true"
+              data-final-drawing-events={Jason.encode!(@final_entry.value || [])}
+              class="mt-4"
+            >
+              <div class="relative aspect-[7/5] w-full border-2 border-border bg-white">
+                <canvas width="700" height="500" class="absolute inset-0 h-full w-full"></canvas>
+                <.drawing_fallback ops={@final_entry.value || []} />
+              </div>
+            </div>
+          <% else %>
+            <p
+              id="telephone-return-text"
+              class="flex min-h-44 items-center justify-center p-4 text-center font-hero text-3xl font-black text-pink-600 sm:text-4xl"
+            >
+              “{present_text(@final_entry && @final_entry.value)}”
+            </p>
+          <% end %>
+        </.box>
+      </div>
+
+      <.box :if={!@assignment} class="bg-white p-8 text-center">
+        <p id="telephone-return-spectator" class="text-xl font-black">
+          Every chain is back with its owner. The grand reveal is almost here.
+        </p>
+      </.box>
+
+      <div
+        id="telephone-return-controls"
+        class="border-2 border-border bg-white p-5 text-center shadow-shadow"
+      >
+        <p class="mb-3 font-bold text-gray-600">Take it in—there’s no timer on this moment.</p>
+        <.button
+          :if={@viewer_id == @host_id}
+          id="start-telephone-reveal"
+          phx-click="start_reveal"
+          class="min-w-64 justify-center px-8 py-3 text-lg font-black"
+        >
+          Start the grand reveal <.icon name={:sparkles} class="ml-2 h-5 w-5" />
+        </.button>
+        <p
+          :if={@viewer_id != @host_id}
+          id="waiting-for-return-host"
+          class="font-bold text-gray-600"
+        >
+          Waiting for the host to gather everyone for the reveal…
+        </p>
+      </div>
+    </section>
+    """
+  end
+
   attr :reveal, :map, default: nil
   attr :players, :map, required: true
   attr :viewer_id, :any, required: true

--- a/lib/flamingo_web/live/telephone_live.ex
+++ b/lib/flamingo_web/live/telephone_live.ex
@@ -109,6 +109,13 @@ defmodule FlamingoWeb.TelephoneLive do
                 submitted={submitted?(assigns)}
                 form={@guess_form}
               />
+            <% :telephone_return -> %>
+              <TelephoneComponents.return_phase
+                assignment={@assignment}
+                players={@players}
+                viewer_id={@viewer_id}
+                host_id={@host_id}
+              />
             <% :telephone_reveal -> %>
               <TelephoneComponents.reveal_phase
                 reveal={@reveal}
@@ -171,6 +178,8 @@ defmodule FlamingoWeb.TelephoneLive do
   def handle_event("submit_guess", %{"guess" => %{"text" => text}}, socket) do
     command(socket, {:submit_guess, text}, reset_form?: true)
   end
+
+  def handle_event("start_reveal", _params, socket), do: command(socket, :start_reveal)
 
   def handle_event("advance_reveal", _params, socket), do: command(socket, :advance_reveal)
 

--- a/test/flamingo/game_modes/telephone_test.exs
+++ b/test/flamingo/game_modes/telephone_test.exs
@@ -7,19 +7,25 @@ defmodule Flamingo.GameModes.TelephoneTest do
     names = %{"a" => "Alice", "b" => "Bob", "c" => "Cara", "s" => "Sam"}
 
     %{
-      players: Map.new(order, &{&1, %{id: &1, name: names[&1], connected: true}}),
+      players:
+        Map.new(
+          order,
+          &{&1, %{id: &1, name: Map.get(names, &1, String.upcase(&1)), connected: true}}
+        ),
       player_order: order,
       host_id: "a"
     }
   end
 
-  defp context(roster, actor \\ "a") do
+  defp context(roster, actor \\ "a", options \\ []) do
     %{
       roster: roster,
       actor_id: actor,
       now: ~U[2026-01-01 00:00:00Z],
-      word_choices: fn _count, _used, _custom, _defaults -> ["cat", "dog", "bird"] end,
-      select_candidate: &List.first/1
+      word_choices: fn count, _used, _custom, _defaults ->
+        Enum.take(["cat", "dog", "bird", "fish", "horse", "frog"], count)
+      end,
+      select_candidate: Keyword.get(options, :select_candidate, &List.first/1)
     }
   end
 
@@ -35,7 +41,7 @@ defmodule Flamingo.GameModes.TelephoneTest do
       end)
 
     {:ok, %{state: state}} =
-      Telephone.start(state, %{turn_length: 15}, context(game_roster))
+      Telephone.start(state, %{turn_length: 15}, context(game_roster, "a", opts))
 
     state =
       if Keyword.get(opts, :choose_prompts, true) do
@@ -122,6 +128,44 @@ defmodule Flamingo.GameModes.TelephoneTest do
     assert state.phase == :telephone_draw
     assert Telephone.view(state, "a", game_roster).assignment.chain_id == "telephone-chain-1"
     assert Telephone.view(state, "a", game_roster).assignment.source.value == "guess c"
+  end
+
+  test "randomizes the pass order while every player contributes to every chain once" do
+    pick_middle = &Enum.at(&1, div(length(&1), 2))
+    order = ["a", "b", "c", "d", "e"]
+    {state, game_roster} = started(order, select_candidate: pick_middle)
+
+    assert state.step_offsets == [0, 3, 2, 4, 1]
+
+    {assignments, reveal} =
+      Enum.map_reduce(1..length(order), state, fn _step, state ->
+        round_assignments =
+          Map.new(order, fn player_id ->
+            assignment = Telephone.view(state, player_id, game_roster).assignment
+            {player_id, assignment.chain_id}
+          end)
+
+        {round_assignments, submit_everyone(state, game_roster)}
+      end)
+
+    chain_ids = MapSet.new(Enum.map(reveal.chains, & &1.id))
+
+    assert Enum.all?(assignments, fn round ->
+             round |> Map.values() |> MapSet.new() == chain_ids
+           end)
+
+    assert Enum.all?(order, fn player_id ->
+             assignments
+             |> Enum.map(&Map.fetch!(&1, player_id))
+             |> MapSet.new() == chain_ids
+           end)
+
+    assert Enum.all?(reveal.chains, fn chain ->
+             chain.entries
+             |> tl()
+             |> Enum.map(& &1.player_id)
+             |> MapSet.new() == MapSet.new(order)
+           end)
   end
 
   test "timeout records placeholders and a disconnect completes the online set" do

--- a/test/flamingo/game_modes/telephone_test.exs
+++ b/test/flamingo/game_modes/telephone_test.exs
@@ -130,14 +130,14 @@ defmodule Flamingo.GameModes.TelephoneTest do
     assert Telephone.view(state, "a", game_roster).assignment.source.value == "guess c"
   end
 
-  test "randomizes the pass order while every player contributes to every chain once" do
+  test "uses one shuffled circle, returns each chain privately, and waits for the host" do
     pick_middle = &Enum.at(&1, div(length(&1), 2))
     order = ["a", "b", "c", "d", "e"]
     {state, game_roster} = started(order, select_candidate: pick_middle)
 
-    assert state.step_offsets == [0, 3, 2, 4, 1]
+    assert state.pass_order == ["c", "d", "b", "e", "a"]
 
-    {assignments, reveal} =
+    {assignments, returned} =
       Enum.map_reduce(1..length(order), state, fn _step, state ->
         round_assignments =
           Map.new(order, fn player_id ->
@@ -148,7 +148,7 @@ defmodule Flamingo.GameModes.TelephoneTest do
         {round_assignments, submit_everyone(state, game_roster)}
       end)
 
-    chain_ids = MapSet.new(Enum.map(reveal.chains, & &1.id))
+    chain_ids = MapSet.new(Enum.map(returned.chains, & &1.id))
 
     assert Enum.all?(assignments, fn round ->
              round |> Map.values() |> MapSet.new() == chain_ids
@@ -160,12 +160,37 @@ defmodule Flamingo.GameModes.TelephoneTest do
              |> MapSet.new() == chain_ids
            end)
 
-    assert Enum.all?(reveal.chains, fn chain ->
-             chain.entries
-             |> tl()
-             |> Enum.map(& &1.player_id)
-             |> MapSet.new() == MapSet.new(order)
+    assert Enum.all?(returned.chains, fn chain ->
+             origin_index = Enum.find_index(returned.pass_order, &(&1 == chain.origin_player_id))
+
+             expected_circle =
+               Enum.drop(returned.pass_order, origin_index) ++
+                 Enum.take(returned.pass_order, origin_index)
+
+             Enum.map(tl(chain.entries), & &1.player_id) == expected_circle
            end)
+
+    assert returned.phase == :telephone_return
+
+    assert Enum.all?(order, fn player_id ->
+             view = Telephone.view(returned, player_id, game_roster)
+             chain = Enum.find(returned.chains, &(&1.origin_player_id == player_id))
+
+             view.reveal == nil and view.assignment.type == :return and
+               view.assignment.chain_id == chain.id and
+               view.assignment.origin == List.first(chain.entries) and
+               view.assignment.source == List.last(chain.entries) and
+               not Map.has_key?(view.assignment, :entries)
+           end)
+
+    assert {:error, :not_host} =
+             Telephone.command(returned, "b", :start_reveal, context(game_roster, "b"))
+
+    {:ok, %{state: reveal}} =
+      Telephone.command(returned, "a", :start_reveal, context(game_roster))
+
+    assert reveal.phase == :telephone_reveal
+    assert length(Telephone.view(reveal, "b", game_roster).reveal.chain.entries) == 1
   end
 
   test "timeout records placeholders and a disconnect completes the online set" do
@@ -180,9 +205,9 @@ defmodule Flamingo.GameModes.TelephoneTest do
     assert state.phase == :telephone_guess
     assert Enum.at(state.chains, 1).entries |> List.last() |> Map.fetch!(:value) == nil
 
-    {:ok, %{state: reveal}} = Telephone.timeout(state, :telephone_step, context(offline_roster))
-    assert reveal.phase == :telephone_reveal
-    assert Enum.all?(reveal.chains, &(length(&1.entries) == 3))
+    {:ok, %{state: returned}} = Telephone.timeout(state, :telephone_step, context(offline_roster))
+    assert returned.phase == :telephone_return
+    assert Enum.all?(returned.chains, &(length(&1.entries) == 3))
   end
 
   test "timeout and disconnect preserve drawings that already reached the server" do
@@ -349,7 +374,7 @@ defmodule Flamingo.GameModes.TelephoneTest do
 
   test "a new host can continue reveal after every original player is removed" do
     {state, game_roster} = started(["a", "b"])
-    reveal = state |> submit_everyone(game_roster) |> submit_everyone(game_roster)
+    returned = state |> submit_everyone(game_roster) |> submit_everyone(game_roster)
 
     bob_roster = %{
       game_roster
@@ -358,22 +383,25 @@ defmodule Flamingo.GameModes.TelephoneTest do
         host_id: "b"
     }
 
-    {:ok, %{state: reveal}} =
-      Telephone.remove_member(reveal, "a", %{name: "Alice"}, context(bob_roster))
+    {:ok, %{state: returned}} =
+      Telephone.remove_member(returned, "a", %{name: "Alice"}, context(bob_roster))
 
     empty_roster = %{players: %{}, player_order: [], host_id: nil}
 
-    {:ok, %{state: reveal}} =
-      Telephone.remove_member(reveal, "b", %{name: "Bob"}, context(empty_roster))
+    {:ok, %{state: returned}} =
+      Telephone.remove_member(returned, "b", %{name: "Bob"}, context(empty_roster))
 
-    assert reveal.host_id == nil
+    assert returned.host_id == nil
 
     sam_roster = %{roster(["s"]) | host_id: "s"}
 
-    {:ok, %{state: reveal}} =
-      Telephone.admit_member(reveal, sam_roster.players["s"], context(sam_roster, "s"))
+    {:ok, %{state: returned}} =
+      Telephone.admit_member(returned, sam_roster.players["s"], context(sam_roster, "s"))
 
-    assert reveal.host_id == "s"
+    assert returned.host_id == "s"
+
+    assert {:ok, %{state: reveal}} =
+             Telephone.command(returned, "s", :start_reveal, context(sam_roster, "s"))
 
     assert {:ok, _result} =
              Telephone.command(reveal, "s", :advance_reveal, context(sam_roster, "s"))
@@ -382,7 +410,14 @@ defmodule Flamingo.GameModes.TelephoneTest do
   test "host paces leak-free reveal, votes can change, and awards finish deterministically" do
     {state, game_roster} = started(["a", "b"])
     state = state |> submit_everyone(game_roster) |> submit_everyone(game_roster)
-    assert state.phase == :telephone_reveal
+    assert state.phase == :telephone_return
+    assert Telephone.view(state, "b", game_roster).reveal == nil
+
+    assert {:error, :not_host} =
+             Telephone.command(state, "b", :start_reveal, context(game_roster, "b"))
+
+    {:ok, %{state: state}} =
+      Telephone.command(state, "a", :start_reveal, context(game_roster))
 
     view = Telephone.view(state, "b", game_roster)
     assert length(view.reveal.chain.entries) == 1

--- a/test/flamingo_web/live/telephone_live_test.exs
+++ b/test/flamingo_web/live/telephone_live_test.exs
@@ -212,7 +212,15 @@ defmodule FlamingoWeb.TelephoneLiveTest do
     assert has_element?(host, "#telephone-reveal-phase")
     assert has_element?(host, "#revealed-entries article")
     refute has_element?(host, "#revealed-entries article:nth-child(2)")
-    assert has_element?(host, "#advance-telephone-reveal")
+    assert has_element?(host, "#reveal-chain-progress [data-state='current']")
+    assert has_element?(host, "#reveal-link-progress [data-state='current']")
+
+    assert has_element?(
+             host,
+             "#revealed-entries article[data-current='true'][data-entry-type='prompt']"
+           )
+
+    assert has_element?(host, "#advance-telephone-reveal", "Reveal the first drawing")
 
     {:ok, bob_view, _html} =
       live(build_conn(), ~p"/game/#{room_id}/telephone?resume_token=#{bob_token}")
@@ -263,6 +271,13 @@ defmodule FlamingoWeb.TelephoneLiveTest do
     :ok = command_as(room_id, bob_token, {:submit_guess, "cactus"})
     host |> element("#advance-telephone-reveal") |> render_click()
 
+    assert has_element?(
+             host,
+             "#revealed-entries article[data-current='true'][data-entry-type='drawing']"
+           )
+
+    assert has_element?(host, "#advance-telephone-reveal", "Reveal what they guessed")
+
     {:ok, snapshot} = snapshot_as(room_id, host_token)
     drawing = Enum.find(snapshot.reveal.chain.entries, &(&1.type == :drawing))
     vote_id = "vote-worst_drawing-#{drawing.id}"
@@ -276,6 +291,9 @@ defmodule FlamingoWeb.TelephoneLiveTest do
     end
 
     assert has_element?(host, "#telephone-awards")
+    assert has_element?(host, "#telephone-finale-banner")
+    assert has_element?(host, "#telephone-award-cards > div:nth-child(3)")
+    refute has_element?(host, "#telephone-award-cards > div:nth-child(4)")
     assert has_element?(host, "#telephone-play-again")
     assert has_element?(host, "#telephone-new-room")
   end

--- a/test/flamingo_web/live/telephone_live_test.exs
+++ b/test/flamingo_web/live/telephone_live_test.exs
@@ -148,7 +148,7 @@ defmodule FlamingoWeb.TelephoneLiveTest do
     assert has_element?(telephone, "#submit-telephone-drawing")
   end
 
-  test "two players receive private chains and progress through draw, guess, and leak-free reveal",
+  test "chains return privately before the host starts the leak-free reveal",
        %{
          conn: conn,
          room_id: room_id
@@ -209,6 +209,22 @@ defmodule FlamingoWeb.TelephoneLiveTest do
     :ok = command_as(room_id, bob_token, {:submit_guess, "a cactus moon"})
     _ = :sys.get_state(room_pid(room_id))
 
+    assert has_element?(host, "#telephone-return-phase")
+    assert has_element?(host, "#telephone-return-original")
+    assert has_element?(host, "#telephone-return-text", "a cactus moon")
+    refute has_element?(host, "#telephone-return-text", "a moon llama")
+    assert has_element?(host, "#start-telephone-reveal")
+    refute has_element?(host, "#telephone-reveal-phase")
+
+    {:ok, bob_view, _html} =
+      live(build_conn(), ~p"/game/#{room_id}/telephone?resume_token=#{bob_token}")
+
+    assert has_element?(bob_view, "#telephone-return-text", "a moon llama")
+    assert has_element?(bob_view, "#waiting-for-return-host")
+    refute has_element?(bob_view, "#start-telephone-reveal")
+
+    host |> element("#start-telephone-reveal") |> render_click()
+
     assert has_element?(host, "#telephone-reveal-phase")
     assert has_element?(host, "#revealed-entries article")
     refute has_element?(host, "#revealed-entries article:nth-child(2)")
@@ -221,9 +237,6 @@ defmodule FlamingoWeb.TelephoneLiveTest do
            )
 
     assert has_element?(host, "#advance-telephone-reveal", "Reveal the first drawing")
-
-    {:ok, bob_view, _html} =
-      live(build_conn(), ~p"/game/#{room_id}/telephone?resume_token=#{bob_token}")
 
     assert has_element?(bob_view, "#waiting-for-reveal-host")
     refute has_element?(bob_view, "#advance-telephone-reveal")
@@ -269,6 +282,8 @@ defmodule FlamingoWeb.TelephoneLiveTest do
     :ok = command_as(room_id, bob_token, :submit_drawing)
     host |> form("#telephone-guess-form", %{"guess" => %{"text" => "moon"}}) |> render_submit()
     :ok = command_as(room_id, bob_token, {:submit_guess, "cactus"})
+    assert has_element?(host, "#telephone-return-phase")
+    host |> element("#start-telephone-reveal") |> render_click()
     host |> element("#advance-telephone-reveal") |> render_click()
 
     assert has_element?(


### PR DESCRIPTION
## Why

Telephone chains followed the predictable join order, so larger games did not feel sufficiently mixed even though each player took a turn. The reveal also made it difficult to tell which link was new, how far through the stories the room had progressed, or when the finale was approaching.

## Notes

The randomized pass schedule still guarantees that every player contributes to every chain exactly once. Reveals remain host-paced and leak-free while giving each new drawing or guess a clearer dramatic moment, followed by a more celebratory awards screen.