### PR TITLE
Show drawing constraints on the end screen

### DIFF
--- a/lib/flamingo/game_modes/scribble.ex
+++ b/lib/flamingo/game_modes/scribble.ex
@@ -369,6 +369,7 @@ defmodule Flamingo.GameModes.Scribble do
       drawer_id: state.drawer_id,
       word: state.word,
       round_number: state.current_round + 1,
+      constraint: state.constraint,
       ops: DrawingShare.compact_ops(state.current_drawing)
     }
 

--- a/lib/flamingo_web/live/scribble_live.ex
+++ b/lib/flamingo_web/live/scribble_live.ex
@@ -105,6 +105,13 @@ defmodule FlamingoWeb.ScribbleLive do
   defp constraint_label(:mirror), do: "Mirror mode — horizontal movement is reversed"
   defp constraint_label(_constraint), do: nil
 
+  defp constraint_mode(:hidden_canvas), do: "draw blind"
+  defp constraint_mode(:single_stroke), do: "one stroke"
+  defp constraint_mode(:straight_lines), do: "straight lines only"
+  defp constraint_mode(:rotating_canvas), do: "moving target"
+  defp constraint_mode(:mirror), do: "mirror mode"
+  defp constraint_mode(_constraint), do: nil
+
   defp selected_game_mode(:telephone, _variant), do: "telephone"
   defp selected_game_mode(:scribble, :constraint_roulette), do: "constraint_roulette"
   defp selected_game_mode(_mode, _variant), do: "classic"
@@ -646,6 +653,7 @@ defmodule FlamingoWeb.ScribbleLive do
                   <% end %>
                   <%= for drawing <- selected_drawings do %>
                     <% share_url = drawing_share_url(drawing, @final_players) %>
+                    <% drawing_constraint = constraint_mode(Map.get(drawing, :constraint)) %>
                     <div class="border-2 border-border bg-white p-3">
                       <div class="mb-2 flex items-center justify-between gap-3">
                         <span
@@ -679,6 +687,13 @@ defmodule FlamingoWeb.ScribbleLive do
                         <canvas width="700" height="500" class="aspect-[7/5] w-full bg-white">
                         </canvas>
                       </div>
+                      <p
+                        :if={drawing_constraint}
+                        id={"final-drawing-constraint-#{drawing.drawer_id}-round-#{drawing.round_number}"}
+                        class="mt-2 text-center text-sm font-bold text-yellow-600"
+                      >
+                        drawn with {drawing_constraint}
+                      </p>
                     </div>
                   <% end %>
                 </div>

--- a/test/flamingo/game_modes/scribble_test.exs
+++ b/test/flamingo/game_modes/scribble_test.exs
@@ -102,6 +102,14 @@ defmodule Flamingo.GameModes.ScribbleTest do
     assert Scribble.view(roulette, "b", roster()).constraint == :mirror
     assert Scribble.view(roulette, "b", roster()).game_variant == :constraint_roulette
 
+    {:ok, %{state: roulette}} =
+      Scribble.command(roulette, "a", {:select_word, "cat"}, context())
+
+    {:ok, %{state: roulette}} =
+      Scribble.command(roulette, "b", {:guess, "cat"}, context())
+
+    assert [%{constraint: :mirror}] = roulette.final_drawings
+
     {:ok, %{state: classic}} = Scribble.start(admitted(), %{round_count: 1}, context())
     assert classic.constraint == nil
   end

--- a/test/flamingo_web/live/scribble_live_test.exs
+++ b/test/flamingo_web/live/scribble_live_test.exs
@@ -585,6 +585,7 @@ defmodule FlamingoWeb.ScribbleLiveTest do
     assert html =~ "data-final-drawing-replay=\"true\""
     assert html =~ "data-drawing-share-url="
     assert html =~ "/drawing#"
+    refute html =~ "final-drawing-constraint-"
 
     [_, share_url] = Regex.run(~r/data-drawing-share-url="([^"]+)"/, html)
     encoded = share_url |> String.split("/drawing#") |> List.last()
@@ -596,6 +597,50 @@ defmodule FlamingoWeb.ScribbleLiveTest do
             }} = DrawingShare.decode(encoded)
 
     assert drawer_name == winner.name
+  end
+
+  test "game end screen identifies constrained drawings", %{conn: conn, room_id: room_id} do
+    {:ok, p1_token, %{viewer_id: p1}} = join_connected(room_id, "Alice")
+    {:ok, p2_token, %{viewer_id: p2}} = join_connected(room_id, "Bob")
+
+    {:ok, view, _html} = live(conn, ~p"/game/#{room_id}?resume_token=#{p1_token}")
+
+    :ok =
+      start_game_as(room_id, p1_token, %{
+        round_count: 1,
+        turn_length: 30,
+        game_variant: :constraint_roulette
+      })
+
+    play_turn(room_id, p1, p1_token, p2, p2_token)
+    play_turn(room_id, p1, p1_token, p2, p2_token)
+
+    {:ok, snapshot} = snapshot_as(room_id, p1_token)
+
+    winner_id =
+      Enum.max_by(snapshot.final_player_order, fn pid ->
+        Map.fetch!(snapshot.final_players, pid).score
+      end)
+
+    drawing = Enum.find(snapshot.final_drawings, &(&1.drawer_id == winner_id))
+
+    mode =
+      Map.fetch!(
+        %{
+          hidden_canvas: "draw blind",
+          single_stroke: "one stroke",
+          straight_lines: "straight lines only",
+          rotating_canvas: "moving target",
+          mirror: "mirror mode"
+        },
+        drawing.constraint
+      )
+
+    assert has_element?(
+             view,
+             "#final-drawing-constraint-#{winner_id}-round-1.text-yellow-600",
+             "drawn with #{mode}"
+           )
   end
 
   test "final score rows select the drawing showcase", %{


### PR DESCRIPTION
Constraint Roulette drawings currently lose the context of how they were made once the game ends. Preserve each turn's constraint with its finished drawing and show a centered yellow caption beneath the drawing in the end-screen showcase. Standard drawings remain unchanged.