### PR TITLE
Fix rotating canvas constraint

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -219,13 +219,13 @@
   opacity: 0;
 }
 
-@keyframes roulette-canvas-rotate {
-  0%, 100% { transform: rotate(-5deg) scale(0.96); }
-  50% { transform: rotate(5deg) scale(0.96); }
+@keyframes roulette-canvas-frame-rotate {
+  from { transform: rotate(0deg) scale(0.96); }
+  to { transform: rotate(360deg) scale(0.96); }
 }
 
-.roulette-rotating-canvas {
-  animation: roulette-canvas-rotate 8s ease-in-out infinite;
+.roulette-rotating-canvas-frame {
+  animation: roulette-canvas-frame-rotate 8s linear infinite;
   transform-origin: center;
 }
 

--- a/assets/js/hooks/drawing_canvas.ts
+++ b/assets/js/hooks/drawing_canvas.ts
@@ -196,7 +196,9 @@ const DrawingCanvas = {
     }
 
     if (this.isDrawer && this.constraint === "rotating_canvas") {
-      this.canvas.classList.add("roulette-rotating-canvas");
+      this.canvas
+        .closest(".drawing-canvas-frame")
+        ?.classList.add("roulette-rotating-canvas-frame");
     }
 
     if (this.el.dataset.finalDrawingEvents) {

--- a/lib/flamingo_web/components/game_components.ex
+++ b/lib/flamingo_web/components/game_components.ex
@@ -333,7 +333,7 @@ defmodule FlamingoWeb.GameComponents do
       assign(assigns, display: display, hint_chars: hint_chars, letter_count: letter_count)
 
     ~H"""
-    <div class="relative self-center">
+    <div class="relative z-10 self-center">
       <div class={[
         "rounded-full border-2 border-border bg-pink-400 px-10 pt-1 pb-4 shadow-rounded",
         if(!@display, do: "invisible")
@@ -383,7 +383,7 @@ defmodule FlamingoWeb.GameComponents do
 
   def player_list_panel(assigns) do
     ~H"""
-    <div class="relative flex w-full flex-1 flex-col">
+    <div class="relative z-10 flex w-full flex-1 flex-col">
       <p
         id="round-progress"
         class="absolute -top-8 left-1 text-xl leading-none font-black text-black"

--- a/lib/flamingo_web/live/scribble_live.ex
+++ b/lib/flamingo_web/live/scribble_live.ex
@@ -472,7 +472,7 @@ defmodule FlamingoWeb.ScribbleLive do
                       data-constraint={@constraint}
                       class="flex flex-col gap-2"
                     >
-                      <.box class="bg-white p-0">
+                      <.box class="drawing-canvas-frame relative z-0 bg-white p-0">
                         <canvas
                           width="700"
                           height="500"
@@ -488,7 +488,7 @@ defmodule FlamingoWeb.ScribbleLive do
                       </.box>
 
                       <%= if @phase == :playing and @player_id == @drawer_id and @participation == :active do %>
-                        <.box class="bg-white p-0">
+                        <.box class="relative z-10 bg-white p-0">
                           <.drawing_toolbar palette={palette()} />
                         </.box>
                       <% end %>
@@ -496,7 +496,7 @@ defmodule FlamingoWeb.ScribbleLive do
 
                     <%= if @phase == :playing and @player_id != @drawer_id and @participation == :active do %>
                       <%= if MapSet.member?(@correct_guesses, @player_id) do %>
-                        <.box class="bg-green-100 p-3 text-center font-bold text-green-800">
+                        <.box class="relative z-10 bg-green-100 p-3 text-center font-bold text-green-800">
                           You guessed it!
                         </.box>
                       <% else %>
@@ -505,7 +505,7 @@ defmodule FlamingoWeb.ScribbleLive do
                           phx-submit="guess"
                           phx-hook=".GuessForm"
                           id="guess-form"
-                          class="mx-auto flex w-96 items-center gap-2"
+                          class="relative z-10 mx-auto flex w-96 items-center gap-2"
                         >
                           <span
                             id="guess-letter-count"
@@ -532,7 +532,7 @@ defmodule FlamingoWeb.ScribbleLive do
                   </div>
               <% end %>
 
-              <.box class="flex min-h-0 w-full flex-1 flex-col bg-white p-0">
+              <.box class="relative z-10 flex min-h-0 w-full flex-1 flex-col bg-white p-0">
                 <div
                   id="game-feed"
                   phx-hook=".ScrollFeed"


### PR DESCRIPTION
The rotating-canvas constraint currently rocks a few degrees in either direction, which does not match the intended spinning behavior. This changes it to a continuous full rotation and rotates the canvas frame and shadow as one unit. Surrounding game controls are layered above the rotating frame so its corners pass behind the UI rather than covering it.