### PR TITLE
Use path-based room invitation links

### DIFF
--- a/lib/flamingo_web/live/home_live.ex
+++ b/lib/flamingo_web/live/home_live.ex
@@ -4,7 +4,7 @@ defmodule FlamingoWeb.HomeLive do
   alias Flamingo.{Avatar, Rooms}
 
   def mount(params, _session, socket) do
-    room_code = params["room"] || ""
+    room_code = Map.get(params, "room_code", "")
 
     {:ok,
      assign(socket,

--- a/lib/flamingo_web/live/scribble_live.ex
+++ b/lib/flamingo_web/live/scribble_live.ex
@@ -311,7 +311,9 @@ defmodule FlamingoWeb.ScribbleLive do
                           variant="outline"
                           class="text-xs"
                           on_confirm_click={
-                            JS.dispatch("phx:copy", detail: %{text: url(~p"/?room=#{@room_id}")})
+                            JS.dispatch("phx:copy",
+                              detail: %{text: url(~p"/join/#{@room_id}")}
+                            )
                           }
                           id="copy-link-button"
                         >

--- a/lib/flamingo_web/router.ex
+++ b/lib/flamingo_web/router.ex
@@ -18,6 +18,7 @@ defmodule FlamingoWeb.Router do
     pipe_through :browser
 
     live "/", HomeLive
+    live "/join/:room_code", HomeLive
     live "/game/:room_id", ScribbleLive
     live "/game/:room_id/telephone", TelephoneLive
     live "/drawing", DrawingLive

--- a/test/flamingo_web/live/home_live_test.exs
+++ b/test/flamingo_web/live/home_live_test.exs
@@ -6,6 +6,20 @@ defmodule FlamingoWeb.HomeLiveTest do
 
   alias Flamingo.{Rooms, RoomSupervisor}
 
+  test "room invitation path prefills the room code", %{conn: conn} do
+    room_code = "amazing-otter"
+
+    {:ok, view, _html} = live(conn, ~p"/join/#{room_code}")
+
+    assert has_element?(view, "#room-code-input[value='#{room_code}']")
+  end
+
+  test "legacy room query does not prefill the room code", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/?room=legacy-code")
+
+    assert has_element?(view, "#room-code-input[value='']")
+  end
+
   test "submitting the lobby form joins when a room name is present", %{conn: conn} do
     room_id = "home-#{System.unique_integer([:positive])}"
     {:ok, ^room_id} = RoomSupervisor.start_room(room_id)

--- a/test/flamingo_web/live/scribble_live_test.exs
+++ b/test/flamingo_web/live/scribble_live_test.exs
@@ -98,6 +98,22 @@ defmodule FlamingoWeb.ScribbleLiveTest do
     %{room_id: room_id}
   end
 
+  test "host can copy a path-based room invitation", %{conn: conn, room_id: room_id} do
+    {:ok, host_token, _snapshot} = join_connected(room_id, "Alice")
+    {:ok, view, _html} = live(conn, ~p"/game/#{room_id}?resume_token=#{host_token}")
+
+    copy_command =
+      view
+      |> render()
+      |> LazyHTML.from_fragment()
+      |> LazyHTML.query("#copy-link-button")
+      |> LazyHTML.attribute("phx-click")
+      |> List.first()
+
+    assert copy_command =~ url(~p"/join/#{room_id}")
+    refute copy_command =~ "?room="
+  end
+
   test "host settings clamp round length to supported bounds", %{conn: conn, room_id: room_id} do
     {:ok, p1_token, _p1_snapshot} = join_connected(room_id, "Alice")
     {:ok, _p2_token, _p2_snapshot} = join_connected(room_id, "Bob")


### PR DESCRIPTION
Room invitations currently encode the room code in a query parameter, which can be dropped by some browser navigation paths before the connected LiveView mount. Moving the code into a dedicated `/join/:room_code` path keeps the invitation state in the route and reliably prefills the lobby form.\n\nExisting `?room=` links intentionally no longer prefill the room code; backward compatibility was not required.