### PR TITLE
Remove double border from hidden canvas reveal

### DIFF
--- a/lib/flamingo_web/live/scribble_live.ex
+++ b/lib/flamingo_web/live/scribble_live.ex
@@ -432,12 +432,7 @@ defmodule FlamingoWeb.ScribbleLive do
                           )
                         ]}
                       >
-                        <div class={[
-                          "flex w-full flex-col items-center gap-4 px-6",
-                          (@constraint == :hidden_canvas and @player_id == @drawer_id and
-                             @participation == :active) &&
-                            "mx-8 w-auto border-2 border-border bg-white/90 py-4 shadow-shadow"
-                        ]}>
+                        <div class="flex w-full flex-col items-center gap-4 px-6">
                           <div>
                             <p class="text-xl font-black">The word was</p>
                             <p class="font-hero text-5xl leading-none font-black text-pink-400">


### PR DESCRIPTION
The hidden drawing reveal added a bordered content panel over the original canvas, making it appear as though a second canvas had been rendered. Remove that special frame so the completed drawing is revealed directly on the existing canvas.