### PR TITLE
Pause rotating canvas during turn reveal

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -277,6 +277,10 @@
   transform-origin: center;
 }
 
+#drawing-canvas[data-phase="turn_reveal"] .roulette-rotating-canvas-frame {
+  animation-play-state: paused;
+}
+
 .nb-slider {
   -webkit-appearance: none;
   appearance: none;


### PR DESCRIPTION
The rotating-canvas constraint should only move while the drawer is actively drawing. Pause the animation during the turn reveal so the finished whiteboard remains still while players review the word and scores.