### PR TITLE
Simplify avatar customization controls

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -24,6 +24,7 @@ import {Socket} from "phoenix"
 import {LiveSocket} from "phoenix_live_view"
 import {hooks as colocatedHooks} from "phoenix-colocated/flamingo"
 import topbar from "../vendor/topbar"
+import AvatarCustomizer from "./hooks/avatar_customizer"
 import DrawingCanvas from "./hooks/drawing_canvas"
 import FinalDrawingShowcase from "./hooks/final_drawing_showcase"
 import SharedDrawing from "./hooks/shared_drawing"
@@ -45,7 +46,7 @@ const csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute
 const liveSocket = new LiveSocket("/live", Socket, {
   longPollFallbackMs: 2500,
   params: {_csrf_token: csrfToken},
-  hooks: {...colocatedHooks, DrawingCanvas, FinalDrawingShowcase, SharedDrawing, SoundManager},
+  hooks: {AvatarCustomizer, ...colocatedHooks, DrawingCanvas, FinalDrawingShowcase, SharedDrawing, SoundManager},
 })
 
 // Show progress bar on live navigation and form submits

--- a/assets/js/hooks/avatar_customizer.ts
+++ b/assets/js/hooks/avatar_customizer.ts
@@ -1,0 +1,130 @@
+const PARTS = ["head", "body", "legs", "feet"] as const;
+const ANIMAL_COUNT = 5;
+
+type AvatarPart = (typeof PARTS)[number];
+
+interface AvatarCustomizerHook {
+  el: HTMLElement;
+  form: HTMLFormElement;
+  handleClick: (event: MouseEvent) => void;
+  handleInput: () => void;
+}
+
+const inputValue = (root: HTMLElement, id: string) => {
+  const input = root.querySelector<HTMLInputElement>(`#${id}`);
+  return Number.parseInt(input?.value ?? "0", 10);
+};
+
+const selectPart = (root: HTMLElement, part: AvatarPart, value: number) => {
+  const normalized = ((value % ANIMAL_COUNT) + ANIMAL_COUNT) % ANIMAL_COUNT;
+  const template = root.querySelector<HTMLTemplateElement>(
+    `template[data-avatar-template="${normalized}"]`,
+  );
+  const source = template?.content.querySelector<SVGGElement>(`[data-avatar-part-root="${part}"]`);
+  const target = root
+    .querySelector<SVGSVGElement>("svg")
+    ?.querySelector<SVGGElement>(`[data-avatar-part-root="${part}"]`);
+  const input = root.querySelector<HTMLInputElement>(`#avatar-${part}-input`);
+  const label = root.querySelector<HTMLElement>(`#avatar-${part}-animal-name`);
+
+  if (source && target) {
+    target.replaceChildren(...Array.from(source.childNodes, (node) => node.cloneNode(true)));
+  }
+  if (input) input.value = String(normalized);
+  if (label && template?.dataset.avatarAnimalLabel) {
+    label.textContent = template.dataset.avatarAnimalLabel;
+  }
+};
+
+const selectColor = (root: HTMLElement, part: AvatarPart, value: number) => {
+  const options = Array.from(
+    root.querySelectorAll<HTMLButtonElement>(
+      `[data-avatar-color-option][data-avatar-part="${part}"]`,
+    ),
+  );
+  const selected = options.find(
+    (option) => Number.parseInt(option.dataset.avatarValue ?? "0", 10) === value,
+  );
+
+  if (!selected?.dataset.avatarColor) return;
+
+  const input = root.querySelector<HTMLInputElement>(`#avatar-${part}-color-input`);
+  const swatch = root.querySelector<HTMLElement>(`#avatar-${part}-color-button span`);
+  const avatar = root.querySelector<SVGSVGElement>("svg");
+
+  if (input) input.value = String(value);
+  if (swatch) swatch.style.backgroundColor = selected.dataset.avatarColor;
+  avatar?.style.setProperty(`--${part[0]}`, selected.dataset.avatarColor);
+
+  for (const option of options) {
+    const selectedOption = option === selected;
+    option.ariaPressed = String(selectedOption);
+    option.classList.toggle("scale-110", selectedOption);
+  }
+};
+
+const updateLobbyActions = (form: HTMLFormElement) => {
+  const name = form.elements.namedItem("lobby[name]") as HTMLInputElement | null;
+  const room = form.elements.namedItem("lobby[room_code]") as HTMLInputElement | null;
+  const join = form.querySelector<HTMLButtonElement>("#join-button");
+  const create = form.querySelector<HTMLButtonElement>("#create-room-button");
+  const nameEmpty = !name?.value.trim();
+  const roomEmpty = !room?.value.trim();
+
+  if (join) join.disabled = nameEmpty || roomEmpty;
+  if (create) create.disabled = nameEmpty || !roomEmpty;
+};
+
+const AvatarCustomizer = {
+  mounted(this: AvatarCustomizerHook) {
+    this.form = this.el.closest<HTMLFormElement>("form")!;
+    this.handleClick = (event: MouseEvent) => {
+      if (!(event.target instanceof Element)) return;
+
+      const cycle = event.target.closest<HTMLElement>("[data-avatar-cycle]");
+      if (cycle) {
+        const part = cycle.dataset.avatarPart as AvatarPart;
+        const direction = cycle.dataset.avatarDirection === "previous" ? -1 : 1;
+        selectPart(this.el, part, inputValue(this.el, `avatar-${part}-input`) + direction);
+        return;
+      }
+
+      const color = event.target.closest<HTMLButtonElement>("[data-avatar-color-option]");
+      if (color) {
+        selectColor(
+          this.el,
+          color.dataset.avatarPart as AvatarPart,
+          Number.parseInt(color.dataset.avatarValue ?? "0", 10),
+        );
+        return;
+      }
+
+      if (event.target.closest("[data-avatar-random]")) {
+        for (const part of PARTS) {
+          selectPart(this.el, part, Math.floor(Math.random() * ANIMAL_COUNT));
+
+          const colors = this.el.querySelectorAll(
+            `[data-avatar-color-option][data-avatar-part="${part}"]`,
+          );
+          selectColor(this.el, part, Math.floor(Math.random() * colors.length));
+        }
+      }
+    };
+    this.handleInput = () => updateLobbyActions(this.form);
+
+    this.el.addEventListener("click", this.handleClick);
+    this.form.addEventListener("input", this.handleInput);
+    updateLobbyActions(this.form);
+  },
+
+  updated(this: AvatarCustomizerHook) {
+    updateLobbyActions(this.form);
+  },
+
+  destroyed(this: AvatarCustomizerHook) {
+    this.el.removeEventListener("click", this.handleClick);
+    this.form.removeEventListener("input", this.handleInput);
+  },
+};
+
+export default AvatarCustomizer;

--- a/lib/flamingo_web/components/game_components.ex
+++ b/lib/flamingo_web/components/game_components.ex
@@ -109,69 +109,70 @@ defmodule FlamingoWeb.GameComponents do
       role="img"
       aria-label={@label}
       class={@class}
+      style={"--h: #{@head_color}; --b: #{@body_color}; --l: #{@legs_color}; --f: #{@feet_color}"}
       xmlns="http://www.w3.org/2000/svg"
     >
       <%!-- Feet --%>
-      <g fill="none" stroke-linecap="round" stroke-linejoin="round">
+      <g data-avatar-part-root="feet" fill="none" stroke-linecap="round" stroke-linejoin="round">
         <g :if={@avatar["feet"] == 0} stroke-width="5">
           <path d="M45 134 L34 140 M45 134 L45 141 M83 134 L72 140 M83 134 L85 141" stroke="#111827" />
           <path
             d="M45 134 L34 140 M45 134 L45 141 M83 134 L72 140 M83 134 L85 141"
-            stroke={@feet_color}
+            stroke="var(--f)"
             stroke-width="2"
           />
         </g>
-        <g :if={@avatar["feet"] == 1} fill={@feet_color} stroke="#111827" stroke-width="3">
+        <g :if={@avatar["feet"] == 1} fill="var(--f)" stroke="#111827" stroke-width="3">
           <path d="M45 131 Q28 132 29 141 Q39 145 51 139 Z" />
           <path d="M83 131 Q66 132 67 141 Q77 145 89 139 Z" />
         </g>
-        <g :if={@avatar["feet"] == 2} fill={@feet_color} stroke="#111827" stroke-width="3">
+        <g :if={@avatar["feet"] == 2} fill="var(--f)" stroke="#111827" stroke-width="3">
           <ellipse cx="43" cy="137" rx="13" ry="6" /><ellipse cx="82" cy="137" rx="13" ry="6" />
         </g>
-        <g :if={@avatar["feet"] == 3} fill={@feet_color} stroke="#111827" stroke-width="3">
+        <g :if={@avatar["feet"] == 3} fill="var(--f)" stroke="#111827" stroke-width="3">
           <ellipse cx="42" cy="137" rx="15" ry="7" /><ellipse cx="83" cy="137" rx="15" ry="7" />
           <path d="M35 135 L35 140 M42 134 L42 141 M76 135 L76 140 M83 134 L83 141" />
         </g>
-        <g :if={@avatar["feet"] == 4} fill={@feet_color} stroke="#111827" stroke-width="3">
+        <g :if={@avatar["feet"] == 4} fill="var(--f)" stroke="#111827" stroke-width="3">
           <path d="M45 132 Q26 132 24 141 Q39 146 53 139 Z" />
           <path d="M83 132 Q64 132 62 141 Q77 146 91 139 Z" />
         </g>
       </g>
 
       <%!-- Legs --%>
-      <g fill="none" stroke-linecap="round" stroke-linejoin="round">
+      <g data-avatar-part-root="legs" fill="none" stroke-linecap="round" stroke-linejoin="round">
         <g :if={@avatar["legs"] == 0}>
           <path d="M48 96 L45 134 M72 96 L83 134" stroke="#111827" stroke-width="8" />
-          <path d="M48 96 L45 134 M72 96 L83 134" stroke={@legs_color} stroke-width="4" />
+          <path d="M48 96 L45 134 M72 96 L83 134" stroke="var(--l)" stroke-width="4" />
         </g>
         <g :if={@avatar["legs"] == 1}>
           <path d="M47 96 Q40 113 45 134 M73 96 Q80 113 83 134" stroke="#111827" stroke-width="12" />
-          <path d="M47 96 Q40 113 45 134 M73 96 Q80 113 83 134" stroke={@legs_color} stroke-width="7" />
+          <path d="M47 96 Q40 113 45 134 M73 96 Q80 113 83 134" stroke="var(--l)" stroke-width="7" />
         </g>
         <g :if={@avatar["legs"] == 2}>
           <path d="M47 96 Q31 110 45 134 M73 96 Q96 109 83 134" stroke="#111827" stroke-width="14" />
-          <path d="M47 96 Q31 110 45 134 M73 96 Q96 109 83 134" stroke={@legs_color} stroke-width="9" />
+          <path d="M47 96 Q31 110 45 134 M73 96 Q96 109 83 134" stroke="var(--l)" stroke-width="9" />
         </g>
         <g :if={@avatar["legs"] == 3}>
           <path d="M47 96 L40 116 L45 134 M73 96 L88 115 L83 134" stroke="#111827" stroke-width="12" />
           <path
             d="M47 96 L40 116 L45 134 M73 96 L88 115 L83 134"
-            stroke={@legs_color}
+            stroke="var(--l)"
             stroke-width="7"
           />
         </g>
         <g :if={@avatar["legs"] == 4}>
           <path d="M47 96 Q46 114 45 134 M73 96 Q82 113 83 134" stroke="#111827" stroke-width="10" />
-          <path d="M47 96 Q46 114 45 134 M73 96 Q82 113 83 134" stroke={@legs_color} stroke-width="5" />
+          <path d="M47 96 Q46 114 45 134 M73 96 Q82 113 83 134" stroke="var(--l)" stroke-width="5" />
         </g>
       </g>
 
       <%!-- Body --%>
-      <g stroke="#111827" stroke-width="4" stroke-linejoin="round">
+      <g data-avatar-part-root="body" stroke="#111827" stroke-width="4" stroke-linejoin="round">
         <g :if={@avatar["body"] == 0}>
           <path
             d="M28 72 L10 64 L18 82 Q22 103 62 105 Q94 105 103 82 Q86 65 55 65 Q37 65 28 72 Z"
-            fill={@body_color}
+            fill="var(--b)"
           />
           <path
             d="M35 76 Q58 65 86 80 Q72 99 42 96 Z"
@@ -181,7 +182,7 @@ defmodule FlamingoWeb.GameComponents do
           />
         </g>
         <g :if={@avatar["body"] == 1}>
-          <path d="M28 68 Q16 79 23 101 Q34 110 92 102 Q101 83 91 68 Z" fill={@body_color} />
+          <path d="M28 68 Q16 79 23 101 Q34 110 92 102 Q101 83 91 68 Z" fill="var(--b)" />
           <path
             d="M38 70 L34 91 M58 68 L57 94 M79 70 L84 91"
             fill="none"
@@ -190,19 +191,19 @@ defmodule FlamingoWeb.GameComponents do
           />
         </g>
         <g :if={@avatar["body"] == 2}>
-          <ellipse cx="60" cy="84" rx="45" ry="25" fill={@body_color} />
+          <ellipse cx="60" cy="84" rx="45" ry="25" fill="var(--b)" />
           <circle cx="35" cy="79" r="5" fill="white" fill-opacity="0.35" stroke="none" />
           <circle cx="77" cy="91" r="7" fill="white" fill-opacity="0.35" stroke="none" />
         </g>
         <g :if={@avatar["body"] == 3}>
-          <ellipse cx="60" cy="83" rx="34" ry="31" fill={@body_color} />
+          <ellipse cx="60" cy="83" rx="34" ry="31" fill="var(--b)" />
           <ellipse cx="60" cy="88" rx="20" ry="19" fill="white" fill-opacity="0.3" stroke-width="3" />
           <circle cx="94" cy="77" r="10" fill="white" />
         </g>
         <g :if={@avatar["body"] == 4}>
           <path
             d="M18 75 Q31 56 72 63 Q97 66 105 84 Q93 105 55 105 Q22 104 18 75 Z"
-            fill={@body_color}
+            fill="var(--b)"
           />
           <path
             d="M50 72 Q75 66 91 83 Q75 99 52 96 Q42 84 50 72 Z"
@@ -214,11 +215,17 @@ defmodule FlamingoWeb.GameComponents do
       </g>
 
       <%!-- Head --%>
-      <g stroke="#111827" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+      <g
+        data-avatar-part-root="head"
+        stroke="#111827"
+        stroke-width="4"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
         <g :if={@avatar["head"] == 0}>
           <path d="M51 68 Q36 51 54 38" fill="none" stroke="#111827" stroke-width="19" />
-          <path d="M51 68 Q36 51 54 38" fill="none" stroke={@head_color} stroke-width="13" />
-          <circle cx="61" cy="29" r="20" fill={@head_color} />
+          <path d="M51 68 Q36 51 54 38" fill="none" stroke="var(--h)" stroke-width="13" />
+          <circle cx="61" cy="29" r="20" fill="var(--h)" />
           <circle cx="68" cy="25" r="5" fill="white" stroke-width="2" /><circle
             cx="69"
             cy="26"
@@ -232,12 +239,12 @@ defmodule FlamingoWeb.GameComponents do
         <g :if={@avatar["head"] == 1}>
           <path
             d="M51 45 Q64 51 78 45 L80 73 Q65 79 48 72 Z"
-            fill={@head_color}
+            fill="var(--h)"
             stroke="none"
           />
           <path
             d="M39 20 L43 4 L56 15 Q67 10 78 15 L91 5 L89 29 Q88 49 65 54 Q40 50 39 20 Z"
-            fill={@head_color}
+            fill="var(--h)"
           />
           <circle cx="56" cy="29" r="3" fill="#111827" stroke="none" /><circle
             cx="75"
@@ -249,12 +256,12 @@ defmodule FlamingoWeb.GameComponents do
           <path d="M61 37 Q66 41 71 37 M66 38 L66 43" fill="none" stroke-width="2.5" />
         </g>
         <g :if={@avatar["head"] == 2}>
-          <ellipse cx="64" cy="34" rx="29" ry="21" fill={@head_color} />
-          <circle cx="48" cy="14" r="10" fill={@head_color} /><circle
+          <ellipse cx="64" cy="34" rx="29" ry="21" fill="var(--h)" />
+          <circle cx="48" cy="14" r="10" fill="var(--h)" /><circle
             cx="80"
             cy="14"
             r="10"
-            fill={@head_color}
+            fill="var(--h)"
           />
           <circle cx="48" cy="14" r="4" fill="#111827" stroke="none" /><circle
             cx="80"
@@ -266,9 +273,9 @@ defmodule FlamingoWeb.GameComponents do
           <path d="M52 39 Q64 48 76 39" fill="none" stroke-width="2.5" />
         </g>
         <g :if={@avatar["head"] == 3}>
-          <ellipse cx="52" cy="14" rx="9" ry="22" fill={@head_color} transform="rotate(-8 52 14)" />
-          <ellipse cx="77" cy="14" rx="9" ry="22" fill={@head_color} transform="rotate(8 77 14)" />
-          <ellipse cx="64" cy="36" rx="26" ry="22" fill={@head_color} />
+          <ellipse cx="52" cy="14" rx="9" ry="22" fill="var(--h)" transform="rotate(-8 52 14)" />
+          <ellipse cx="77" cy="14" rx="9" ry="22" fill="var(--h)" transform="rotate(8 77 14)" />
+          <ellipse cx="64" cy="36" rx="26" ry="22" fill="var(--h)" />
           <circle cx="55" cy="32" r="3" fill="#111827" stroke="none" /><circle
             cx="73"
             cy="32"
@@ -279,7 +286,7 @@ defmodule FlamingoWeb.GameComponents do
           <path d="M60 40 Q64 44 68 40" fill="none" stroke-width="2.5" />
         </g>
         <g :if={@avatar["head"] == 4}>
-          <circle cx="61" cy="30" r="23" fill={@head_color} />
+          <circle cx="61" cy="30" r="23" fill="var(--h)" />
           <circle cx="54" cy="26" r="3" fill="#111827" stroke="none" /><circle
             cx="69"
             cy="26"

--- a/lib/flamingo_web/live/home_live.ex
+++ b/lib/flamingo_web/live/home_live.ex
@@ -11,7 +11,6 @@ defmodule FlamingoWeb.HomeLive do
        name: "",
        room_code: room_code,
        avatar: Avatar.random(),
-       active_part: "head",
        error: nil
      )}
   end
@@ -19,18 +18,17 @@ defmodule FlamingoWeb.HomeLive do
   def render(assigns) do
     ~H"""
     <Layouts.app flash={@flash}>
-      <div class="flex min-h-screen w-full flex-col items-center justify-center gap-4 px-4 py-8">
+      <div class="flex min-h-screen w-full flex-col items-center justify-center gap-4 px-4 py-8 max-[359px]:px-1">
         <.card class="w-full max-w-xs bg-white px-6 py-4">
           <div class="flex justify-center">
             <.logo />
           </div>
         </.card>
 
-        <.card class="w-full max-w-4xl overflow-hidden bg-white p-0">
+        <.card class="w-full max-w-[44rem] overflow-visible bg-white p-0">
           <.form
             for={%{}}
             as={:lobby}
-            phx-change="update_fields"
             phx-submit="submit_lobby"
             id="lobby-form"
           >
@@ -44,156 +42,169 @@ defmodule FlamingoWeb.HomeLive do
             >
               Submit
             </button>
-            <div class="grid lg:grid-cols-[minmax(270px,0.8fr)_minmax(440px,1.2fr)]">
+
+            <div class="grid lg:grid-cols-[minmax(400px,4fr)_minmax(300px,3fr)]">
               <section
                 id="avatar-customizer"
-                class="relative flex flex-col items-center justify-center overflow-hidden border-b-2 border-border bg-pink-100 p-6 lg:border-r-2 lg:border-b-0"
+                phx-hook="AvatarCustomizer"
+                phx-update="ignore"
+                class="relative flex flex-col items-center justify-center bg-white px-3 py-5 max-[359px]:px-1 sm:p-4"
               >
-                <div class="absolute inset-x-0 top-0 flex items-center justify-between p-4">
-                  <span class="rounded-full border-2 border-border bg-white px-3 py-1 text-[11px] font-black uppercase tracking-[0.18em]">
-                    Your creature
-                  </span>
-                  <button
-                    type="button"
-                    phx-click="randomize_avatar"
-                    id="randomize-avatar-button"
-                    class="group flex items-center gap-1.5 rounded-full border-2 border-border bg-yellow-200 px-3 py-1 text-xs font-black shadow-[2px_2px_0_#000] transition-all hover:-translate-y-0.5 hover:shadow-[3px_3px_0_#000] active:translate-x-0.5 active:translate-y-0.5 active:shadow-none"
-                  >
-                    <.icon
-                      name={:sparkles}
-                      class="size-3.5 transition-transform group-hover:rotate-12"
-                    /> Remix
-                  </button>
-                </div>
+                <input
+                  :for={part <- Avatar.parts()}
+                  type="hidden"
+                  id={"avatar-#{part}-input"}
+                  name={"lobby[#{part}]"}
+                  value={@avatar[part]}
+                />
+                <input
+                  :for={part <- Avatar.parts()}
+                  type="hidden"
+                  id={"avatar-#{part}-color-input"}
+                  name={"lobby[#{part}_color]"}
+                  value={@avatar["#{part}_color"]}
+                />
 
-                <div class="mt-9 flex size-56 items-center justify-center rounded-full border-2 border-border bg-white shadow-[6px_6px_0_#000] sm:size-64">
+                <div class="relative h-56 w-full max-w-xl sm:h-64">
                   <.flamingo_avatar
                     avatar={@avatar}
-                    class="h-48 w-48 drop-shadow-sm sm:h-56 sm:w-56"
+                    class="pointer-events-none absolute top-[43%] left-1/2 z-10 h-30 w-24 -translate-x-1/2 -translate-y-1/2 drop-shadow-sm sm:h-40 sm:w-32"
                     label="Your customized creature"
                   />
-                </div>
 
-                <div
-                  class="mt-5 flex flex-wrap justify-center gap-2"
-                  aria-label="Current creature recipe"
-                >
-                  <button
-                    :for={part <- Avatar.parts()}
-                    type="button"
-                    phx-click="select_avatar_part"
-                    phx-value-part={part}
-                    class={[
-                      "rounded-full border-2 border-border px-2.5 py-1 text-xs font-bold capitalize transition-all hover:-translate-y-0.5",
-                      @active_part == part && "bg-pink-300 shadow-[2px_2px_0_#000]",
-                      @active_part != part && "bg-white"
-                    ]}
+                  <template
+                    :for={{animal, index} <- Avatar.animals()}
+                    data-avatar-template={index}
+                    data-avatar-animal-label={animal}
                   >
-                    {part}: {Avatar.animal_label(@avatar[part])}
+                    <.flamingo_avatar avatar={
+                      Map.merge(@avatar, %{
+                        "head" => index,
+                        "body" => index,
+                        "legs" => index,
+                        "feet" => index
+                      })
+                    } />
+                  </template>
+
+                  <div
+                    id="avatar-selector-rows"
+                    class="absolute inset-x-0 top-1/2 z-20 flex -translate-y-1/2 flex-col gap-3"
+                  >
+                    <div
+                      :for={part <- Avatar.parts()}
+                      class="grid grid-cols-[minmax(4rem,1fr)_6rem_minmax(4.5rem,1fr)] items-center min-[360px]:grid-cols-[minmax(4rem,1fr)_8rem_minmax(4.5rem,1fr)] sm:grid-cols-[minmax(6rem,1fr)_10rem_minmax(7rem,1fr)]"
+                    >
+                      <div class="flex items-center justify-end gap-1 sm:gap-2">
+                        <div class="relative flex shrink-0">
+                          <button
+                            type="button"
+                            phx-click={
+                              JS.show(
+                                to: "#avatar-#{part}-color-picker",
+                                display: "grid"
+                              )
+                            }
+                            id={"avatar-#{part}-color-button"}
+                            aria-label={"Choose #{part} colour"}
+                            class="group flex size-8 shrink-0 items-center justify-center transition-transform hover:scale-110 focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-95 sm:size-9"
+                          >
+                            <span
+                              class="size-6 rounded-full border-2 border-border transition-transform group-hover:scale-110 max-[359px]:size-5 sm:size-[1.6rem]"
+                              style={"background-color: #{Avatar.color(@avatar["#{part}_color"])}"}
+                            >
+                            </span>
+                          </button>
+
+                          <div
+                            id={"avatar-#{part}-color-picker"}
+                            role="group"
+                            aria-label={"Choose #{part} colour"}
+                            phx-click-away={JS.hide(to: "#avatar-#{part}-color-picker")}
+                            phx-window-keydown={JS.hide(to: "#avatar-#{part}-color-picker")}
+                            phx-key="escape"
+                            style="display: none"
+                            class="absolute top-1/2 right-[calc(100%-0.25rem)] z-50 grid -translate-y-1/2 grid-cols-[repeat(2,1.25rem)] gap-1 rounded-md border-2 border-border bg-white p-0.5 max-[359px]:right-[calc(100%-0.375rem)]"
+                          >
+                            <button
+                              :for={{color, index} <- Avatar.colors()}
+                              type="button"
+                              phx-click={JS.hide(to: "#avatar-#{part}-color-picker")}
+                              data-avatar-color-option
+                              data-avatar-part={part}
+                              data-avatar-value={index}
+                              data-avatar-color={color}
+                              id={"avatar-#{part}-color-option-#{index}"}
+                              aria-label={"Select colour #{index + 1}"}
+                              aria-pressed={to_string(@avatar["#{part}_color"] == index)}
+                              class={[
+                                "size-5 rounded-full transition-transform hover:scale-110 focus-visible:outline-2 focus-visible:outline-offset-2",
+                                @avatar["#{part}_color"] == index && "scale-110"
+                              ]}
+                              style={"background-color: #{color}"}
+                            >
+                            </button>
+                          </div>
+                        </div>
+                        <button
+                          type="button"
+                          data-avatar-cycle
+                          data-avatar-part={part}
+                          data-avatar-direction="previous"
+                          id={"avatar-#{part}-previous"}
+                          aria-label={"Previous #{part} animal"}
+                          class="flex size-8 shrink-0 items-center justify-center transition-transform hover:-translate-x-0.5 hover:scale-110 focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-95 sm:size-9"
+                        >
+                          <.icon
+                            name={:chevron_left}
+                            class="size-5 stroke-[3] max-[359px]:size-4 sm:size-5"
+                          />
+                        </button>
+                      </div>
+
+                      <span aria-hidden="true"></span>
+
+                      <div class="flex min-w-0 items-center gap-1 sm:gap-2">
+                        <button
+                          type="button"
+                          data-avatar-cycle
+                          data-avatar-part={part}
+                          data-avatar-direction="next"
+                          id={"avatar-#{part}-next"}
+                          aria-label={"Next #{part} animal"}
+                          class="flex size-8 shrink-0 items-center justify-center transition-transform hover:translate-x-0.5 hover:scale-110 focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-95 sm:size-9"
+                        >
+                          <.icon
+                            name={:chevron_right}
+                            class="size-5 stroke-[3] max-[359px]:size-4 sm:size-5"
+                          />
+                        </button>
+                        <span
+                          id={"avatar-#{part}-animal-name"}
+                          class="block text-sm font-medium whitespace-nowrap capitalize"
+                        >
+                          {Avatar.animal_label(@avatar[part])}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+
+                  <button
+                    type="button"
+                    data-avatar-random
+                    id="randomize-avatar-button"
+                    class="group absolute top-[85%] left-1/2 flex -translate-x-1/2 items-center gap-1.5 rounded-full border-2 border-border bg-yellow-200 px-3 py-1 text-xs font-black transition-all hover:-translate-y-0.5 hover:bg-yellow-300 focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-95"
+                  >
+                    <.icon
+                      name={:dice_5}
+                      class="size-3.5 transition-transform group-hover:rotate-12"
+                    /> Random
                   </button>
                 </div>
               </section>
 
-              <div class="flex flex-col">
-                <section class="border-b-2 border-border p-5 sm:p-6">
-                  <div class="mb-5">
-                    <p class="text-xs font-black uppercase tracking-[0.2em] text-pink-500">
-                      Build your own
-                    </p>
-                    <h2 class="font-hero text-3xl leading-tight font-black">
-                      Mix. Match. Make it weird.
-                    </h2>
-                    <p class="mt-1 text-sm text-gray-600">
-                      Choose one part at a time — your creature updates instantly.
-                    </p>
-                  </div>
-
-                  <div
-                    class="grid grid-cols-4 border-2 border-border bg-white"
-                    role="tablist"
-                    aria-label="Creature parts"
-                  >
-                    <button
-                      :for={{part, index} <- Enum.with_index(Avatar.parts())}
-                      type="button"
-                      role="tab"
-                      aria-selected={@active_part == part}
-                      phx-click="select_avatar_part"
-                      phx-value-part={part}
-                      id={"avatar-part-#{part}"}
-                      class={[
-                        "relative px-2 py-3 text-xs font-black uppercase tracking-wide transition-colors sm:text-sm",
-                        index > 0 && "border-l-2 border-border",
-                        @active_part == part && "bg-pink-300",
-                        @active_part != part && "hover:bg-pink-100"
-                      ]}
-                    >
-                      <span class="block capitalize">{part}</span>
-                      <span
-                        :if={@active_part == part}
-                        class="absolute inset-x-3 -bottom-0.5 h-1 bg-black"
-                      >
-                      </span>
-                    </button>
-                  </div>
-
-                  <div
-                    :for={part <- Avatar.parts()}
-                    id={"avatar-#{part}-panel"}
-                    role="tabpanel"
-                    hidden={@active_part != part}
-                    class="pt-5"
-                  >
-                    <fieldset>
-                      <legend class="mb-2 text-xs font-black uppercase tracking-[0.16em] text-gray-500">
-                        Pick an animal
-                      </legend>
-                      <div class="grid grid-cols-5 gap-2">
-                        <label :for={{animal, index} <- Avatar.animals()} class="group cursor-pointer">
-                          <input
-                            type="radio"
-                            name={"lobby[#{part}]"}
-                            value={index}
-                            checked={@avatar[part] == index}
-                            aria-label={"#{part} animal: #{animal}"}
-                            class="peer sr-only"
-                          />
-                          <span class="flex min-h-16 flex-col items-center justify-center gap-1 border-2 border-gray-300 bg-white px-1 py-2 text-center text-[10px] font-black uppercase transition-all group-hover:-translate-y-0.5 group-hover:border-black peer-checked:-translate-y-1 peer-checked:border-black peer-checked:bg-yellow-100 peer-checked:shadow-[3px_3px_0_#000] sm:text-xs">
-                            <span class="text-lg leading-none" aria-hidden="true">
-                              {Enum.at(["🦩", "🐱", "🐸", "🐰", "🦆"], index)}
-                            </span>
-                            {animal}
-                          </span>
-                        </label>
-                      </div>
-                    </fieldset>
-
-                    <fieldset class="mt-5">
-                      <legend class="mb-2 text-xs font-black uppercase tracking-[0.16em] text-gray-500">
-                        Pick a colour
-                      </legend>
-                      <div class="flex flex-wrap gap-2.5">
-                        <label :for={{color, index} <- Avatar.colors()} class="group cursor-pointer">
-                          <input
-                            type="radio"
-                            name={"lobby[#{part}_color]"}
-                            value={index}
-                            checked={@avatar["#{part}_color"] == index}
-                            aria-label={"#{part} colour #{index + 1}"}
-                            class="peer sr-only"
-                          />
-                          <span
-                            class="block size-8 rounded-full border-2 border-border transition-all group-hover:scale-110 peer-checked:-translate-y-1 peer-checked:shadow-[2px_3px_0_#000] peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2"
-                            style={"background-color: #{color}"}
-                          >
-                          </span>
-                        </label>
-                      </div>
-                    </fieldset>
-                  </div>
-                </section>
-
-                <section class="grid gap-4 bg-gray-50 p-5 sm:grid-cols-2 sm:p-6">
+              <div id="lobby-fields-panel" class="flex items-center bg-white">
+                <section class="grid w-full gap-4 p-5 sm:grid-cols-2 sm:p-6 lg:grid-cols-1 lg:p-6">
                   <input
                     type="text"
                     value={@name}
@@ -204,7 +215,7 @@ defmodule FlamingoWeb.HomeLive do
                     id="name-input"
                   />
 
-                  <div class="sm:col-span-2">
+                  <div class="sm:col-span-2 lg:col-span-1">
                     <p :if={@error} class="mb-2 text-sm text-red-400">{@error}</p>
                     <div class="flex flex-row items-start gap-2">
                       <input
@@ -226,7 +237,7 @@ defmodule FlamingoWeb.HomeLive do
                         Join
                       </.button>
                     </div>
-                    <p class="p-2 text-gray-700">or</p>
+                    <p id="lobby-or-divider" class="p-2 text-center text-gray-700">or</p>
                     <.button
                       type="submit"
                       name="lobby[action]"
@@ -247,28 +258,6 @@ defmodule FlamingoWeb.HomeLive do
       </div>
     </Layouts.app>
     """
-  end
-
-  def handle_event("update_fields", %{"lobby" => params}, socket) do
-    {:noreply,
-     assign(socket,
-       name: params["name"] || "",
-       room_code: params["room_code"] || "",
-       avatar: Avatar.normalize(params),
-       error: nil
-     )}
-  end
-
-  def handle_event("randomize_avatar", _params, socket) do
-    {:noreply, assign(socket, avatar: Avatar.random())}
-  end
-
-  def handle_event("select_avatar_part", %{"part" => part}, socket) do
-    if part in Avatar.parts() do
-      {:noreply, assign(socket, active_part: part)}
-    else
-      {:noreply, socket}
-    end
   end
 
   def handle_event("create_room", _params, socket) do

--- a/test/flamingo_web/live/home_live_test.exs
+++ b/test/flamingo_web/live/home_live_test.exs
@@ -27,20 +27,7 @@ defmodule FlamingoWeb.HomeLiveTest do
     {:ok, view, _html} = live(conn, ~p"/")
 
     view
-    |> form("#lobby-form",
-      lobby: %{
-        name: "Alice",
-        room_code: room_id,
-        head: "1",
-        head_color: "6",
-        body: "4",
-        body_color: "3",
-        legs: "2",
-        legs_color: "7",
-        feet: "3",
-        feet_color: "5"
-      }
-    )
+    |> form("#lobby-form", lobby: %{name: "Alice", room_code: room_id})
     |> render_submit()
 
     {path, _flash} = assert_redirect(view)
@@ -50,18 +37,7 @@ defmodule FlamingoWeb.HomeLiveTest do
     assert %{"resume_token" => resume_token} = URI.decode_query(uri.query)
     assert resume_token != ""
 
-    assert {:ok, state} = Rooms.connect(room_id, resume_token)
-
-    assert state.players[state.viewer_id].avatar == %{
-             "head" => 1,
-             "head_color" => 6,
-             "body" => 4,
-             "body_color" => 3,
-             "legs" => 2,
-             "legs_color" => 7,
-             "feet" => 3,
-             "feet_color" => 5
-           }
+    assert {:ok, _state} = Rooms.connect(room_id, resume_token)
   end
 
   test "submitting the lobby form creates when room name is empty", %{conn: conn} do
@@ -84,40 +60,6 @@ defmodule FlamingoWeb.HomeLiveTest do
 
     assert has_element?(view, "#join-button[type='submit']")
     assert has_element?(view, "#create-room-button[type='submit']")
-  end
-
-  test "home lets players mix animal parts and colors without showing every panel", %{conn: conn} do
-    {:ok, view, _html} = live(conn, ~p"/")
-
-    assert has_element?(view, "#avatar-customizer svg[aria-label='Your customized creature']")
-    assert has_element?(view, "#randomize-avatar-button[type='button']")
-
-    for part <- ~w(head body legs feet) do
-      assert has_element?(view, "#avatar-part-#{part}[role='tab']")
-      assert has_element?(view, "#avatar-#{part}-panel[role='tabpanel']")
-
-      for animal <- 0..4 do
-        assert has_element?(
-                 view,
-                 "input[type='radio'][name='lobby[#{part}]'][value='#{animal}']"
-               )
-      end
-
-      for color <- 0..7 do
-        assert has_element?(
-                 view,
-                 "input[type='radio'][name='lobby[#{part}_color]'][value='#{color}']"
-               )
-      end
-    end
-
-    assert has_element?(view, "#avatar-head-panel:not([hidden])")
-    assert has_element?(view, "#avatar-body-panel[hidden]")
-
-    view |> element("#avatar-part-body") |> render_click()
-
-    assert has_element?(view, "#avatar-head-panel[hidden]")
-    assert has_element?(view, "#avatar-body-panel:not([hidden])")
   end
 
   test "app layout sound control is a volume slider initialized to full volume" do


### PR DESCRIPTION
The avatar builder required moving through separate body-part, animal, and colour panels, making the landing form feel much more complicated than the rest of the flow.

This consolidates customization around the avatar itself, replaces the oversized colour picker with compact palettes, and keeps customization local until the lobby form is submitted. The room details remain focused in the simpler right-hand panel.